### PR TITLE
fix: add MIT license, contributing guide, and node24 CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+env:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   pages: write
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+env:
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   goreleaser:
     name: GoReleaser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+## Prerequisites
+
+- Go 1.26+
+- Docker (required for integration tests)
+- [golangci-lint](https://golangci-lint.run/welcome/install/) v2.10.1
+
+## Local setup
+
+```bash
+git clone https://github.com/seznam/jailoc
+cd jailoc
+go build ./cmd/jailoc
+```
+
+## Testing
+
+Unit tests run without any external dependencies:
+
+```bash
+go test ./...
+```
+
+Integration tests require a running Docker daemon:
+
+```bash
+go test -tags=integration ./...
+```
+
+Write tests for every new behavior. Unit tests belong next to the source file they cover (`*_test.go`), use `t.Parallel()`, and follow table-driven style with `t.Run`. Integration tests live in `internal/integration_test.go` and carry the `//go:build integration` build tag.
+
+## Before committing
+
+```bash
+go fmt ./...
+golangci-lint run
+go test ./...
+```
+
+CI runs `go build`, `go test`, `go vet`, and `golangci-lint` (gosec, staticcheck, gocritic) on every push and PR. A failing lint or test blocks merge.
+
+## Commit messages
+
+Single line, imperative mood:
+
+```
+type(scope): description
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`. No body, no footer, no `Signed-off-by`.
+
+```
+feat(workspace): add port collision detection
+fix(docker): handle nil client on early exit
+test(config): cover invalid CIDR validation
+```
+
+## Pull requests
+
+1. Branch from `master`: `git checkout -b type/short-description`
+2. Keep changes focused — one logical change per PR
+3. All CI checks must pass
+4. Open the PR against `master`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ go test ./...
 
 CI runs `go build`, `go test`, `go vet`, and `golangci-lint` (gosec, staticcheck, gocritic) on every push and PR. A failing lint or test blocks merge.
 
-## Commit messages
+## Semantic commits
 
 Single line, imperative mood:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seznam.cz, a.s.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Add MIT license (Copyright 2026 Seznam.cz, a.s.)
- Add `CONTRIBUTING.md` with dev setup, testing, commit conventions, and PR process
- Force Node.js 24 for GitHub Actions runners ([deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/))