### PR TITLE
fix(ci): hide chore commits from release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "deps", "section": "Dependencies" },
     { "type": "docs", "section": "Documentation" },
-    { "type": "chore", "section": "Miscellaneous" },
+    { "type": "chore", "section": "Miscellaneous", "hidden": true },
     { "type": "test", "section": "Tests" }
   ],
   "packages": {


### PR DESCRIPTION
## Summary

- Hide `chore` type commits from release-please changelog by setting `"hidden": true` in `changelog-sections`
- Fixes cycled changelogs where each release accumulated all prior `chore(master): release X.Y.Z` merge commits (see #9)