### PR TITLE
fix(docs): recurse into subdirectories when substituting version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: pip install .
       - name: Substitute version
-        run: sed -i "s|{{ version }}|${{ needs.release-please.outputs.tag_name }}|g" docs/*.md
+        run: find docs -name '*.md' -exec sed -i "s|{{ version }}|${{ needs.release-please.outputs.tag_name }}|g" {} +
       - name: Build docs
         run: zensical build --clean
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary

- `sed` glob `docs/*.md` didn't recurse into subdirectories, so `{{ version }}` in `docs/tutorials/getting-started.md` was never substituted
- Replaced with `find docs -name '*.md' -exec sed ...` to cover all nested docs