### PR TITLE
fix: narrow .claude mount to transcripts directory only

### DIFF
--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -11,7 +11,7 @@ flowchart TB
     subgraph oc["opencode"]
       direction TB
       oc_uid["UID 1000 (agent)<br>opencode serve<br>:4096 → host"]
-      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/oc (ro)<br>/etc/jailoc (ro)"]
+      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/oc (ro)<br>~/.claude/transcripts (rw)<br>/etc/jailoc (ro)"]
     end
     subgraph dind["dind (privileged)"]
       direction TB
@@ -44,6 +44,7 @@ The opencode container mounts several things at startup:
 |-------|-----------|---------|
 | Workspace paths | read-write | The directories the agent is working in |
 | `~/.config/opencode` | read-only | Your API keys, model config, provider settings |
+| `~/.claude/transcripts` | read-write | Claude Code session transcripts, persisted back to the host |
 | `/etc/jailoc` | read-only | jailoc's own runtime config, including allowed hosts |
 
 Two named volumes are shared between both containers: one for TLS certificates (so the opencode container can authenticate to the dind daemon) and one for Docker's data directory. A third named volume holds the agent's own data — its SQLite history database and auth tokens. This last volume is intentionally isolated from your host's `~/.local/share/opencode`, so the agent's session history never touches your personal history.

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -12,7 +12,7 @@ services:
 {{- end}}
       - ${HOME}/.config/opencode:/home/agent/.config/opencode:ro
       - ${HOME}/.opencode:/home/agent/.opencode:ro
-      - ${HOME}/.claude:/home/agent/.claude
+      - ${HOME}/.claude/transcripts:/home/agent/.claude/transcripts
       - ${HOME}/.agents:/home/agent/.agents:ro
       - ${HOME}/.config/jailoc/workspaces/{{.WorkspaceName}}:/etc/jailoc:ro
       - opencode-data-{{.WorkspaceName}}:/home/agent/.local/share/opencode

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -54,6 +54,6 @@ iptables -A OUTPUT -d 192.168.0.0/16 -j DROP
 iptables -A OUTPUT -d 169.254.0.0/16 -j DROP
 iptables -A OUTPUT -d 100.64.0.0/10 -j DROP
 
-chown -R 1000:1000 /home/agent/.local /home/agent/.cache
+chown -R 1000:1000 /home/agent/.local /home/agent/.cache /home/agent/.claude
 
 exec setpriv --reuid=1000 --regid=1000 --init-groups --inh-caps=-all --no-new-privs -- env HOME=/home/agent "$@"


### PR DESCRIPTION
## Summary

- Mount only `~/.claude/transcripts` (rw) instead of the entire `~/.claude` directory to avoid leaking Claude Code auth tokens and settings into the sandbox
- Update entrypoint `chown` to cover the narrowed `.claude` path
- Update docs to reflect the new mount scope