### PR TITLE
docs: replace misleading ubuntu:22.04 defaults.image example

### DIFF
--- a/docs/how-to/custom-images.md
+++ b/docs/how-to/custom-images.md
@@ -25,10 +25,12 @@ Set `image` in `[defaults]` to use a pre-built image as the starting point for a
 
 ```toml
 [defaults]
-image = "ubuntu:22.04"
+image = "myregistry.example.com/myteam/opencode-base:v1.2.3"
 ```
 
-With this set, a workspace that adds its own `dockerfile` builds on top of `ubuntu:22.04`:
+The image must contain OpenCode and the required agent tooling (entrypoint, iptables, setpriv). A plain OS image like `ubuntu:22.04` cannot be used here — the container would fail to start. When `defaults.image` is not set, jailoc builds from its embedded Dockerfile automatically.
+
+With this set, a workspace that adds its own `dockerfile` builds on top of the specified image:
 
 ```toml
 [workspaces.myproject]
@@ -36,7 +38,7 @@ paths = ["~/projects/myproject"]
 dockerfile = "~/projects/myproject/overlay.Dockerfile"
 ```
 
-A workspace without a `dockerfile` receives `ubuntu:22.04` as-is.
+A workspace without a `dockerfile` receives the specified image as-is.
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,7 +46,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 
 ```toml
 [defaults]
-image = "ubuntu:22.04"
+image = "myregistry.example.com/myteam/opencode-base:v1.2.3"
 env = ["GOPRIVATE=*.example.com", "NPM_REGISTRY=https://npm.example.com"]
 env_file = ["~/.config/jailoc/shared.env"]
 allowed_hosts = ["internal-registry.example.com"]


### PR DESCRIPTION
## Summary

- Replace `ubuntu:22.04` with `myregistry.example.com/myteam/opencode-base:v1.2.3` in `defaults.image` examples — a plain OS image doesn't contain OpenCode and would fail at container startup.
- Add explicit warning in the custom images how-to that `defaults.image` must contain the agent tooling.