### PR TITLE
feat(attach): fall back to opencode-cli when opencode binary not found

### DIFF
--- a/docs/explanation/access-modes.md
+++ b/docs/explanation/access-modes.md
@@ -25,7 +25,7 @@ The opencode container always runs `opencode serve`. What changes between modes 
 
 Because the terminal UI renders on the host, it uses your host terminal directly. Keyboard shortcuts, clipboard integration, and font rendering all work exactly as they do when running opencode locally. The agent session lives in the container process, so you can disconnect and reconnect without losing state. The container keeps running, the agent keeps its context, and when you reconnect the conversation is exactly where you left it.
 
-The only requirement is that `opencode` is installed and available on your host `PATH`.
+The only requirement is that `opencode` (or `opencode-cli`) is installed and available on your host `PATH`.
 
 If the `opencode` container stops or is recreated while you are attached, `jailoc` cancels the host-side attach process instead of waiting indefinitely. This matters most during rebuilds or bakes that replace the container while your UI is still connected.
 
@@ -62,7 +62,7 @@ Because exec mode puts your terminal into raw mode before entering `docker exec`
 
 | | Remote | Exec |
 |---|--------|------|
-| Host dependency | `opencode` on PATH | Docker only |
+| Host dependency | `opencode` or `opencode-cli` on PATH | Docker only |
 | Terminal experience | Full (renders on host) | Limited (through pipe) |
 | Keyboard shortcuts | Full support | Partial |
 | Disconnect behaviour | Client exits, session persists | Client exits, session persists |
@@ -71,7 +71,7 @@ Because exec mode puts your terminal into raw mode before entering `docker exec`
 
 ## Auto-detection
 
-When no mode is explicitly configured, jailoc detects which mode to use. It checks whether `opencode` is available on the host `PATH`. If found, it uses remote mode. If not, it falls back to exec mode.
+When no mode is explicitly configured, jailoc detects which mode to use. It checks whether `opencode` is available on the host `PATH`, falling back to `opencode-cli` if not found. If either binary is found, it uses remote mode. If neither is found, it falls back to exec mode.
 
 This means the default behaviour changes depending on your host environment. A machine with opencode installed gets a richer experience automatically. A machine without it still works without any configuration change.
 

--- a/docs/how-to/access-modes.md
+++ b/docs/how-to/access-modes.md
@@ -6,10 +6,10 @@ jailoc supports two ways to attach to a running workspace container. This guide 
 
 ## Let jailoc auto-detect (default)
 
-By default, jailoc checks whether `opencode` is on your `PATH`:
+By default, jailoc checks whether `opencode` or `opencode-cli` is on your `PATH`:
 
-- If found, it uses **remote** mode (`opencode attach`).
-- If not found, it falls back to **exec** mode (`docker exec` into the container).
+- If found, it uses **remote** mode (runs whichever binary was found with `attach`).
+- If neither is found, it falls back to **exec** mode (`docker exec` into the container).
 
 You don't need any config for this. Just run:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -29,7 +29,7 @@ jailoc [flags]
 | `--remote` | Force remote connection mode (runs `opencode attach` on the host). |
 | `--exec` | Force exec connection mode (runs `docker exec` into the container). |
 
-When neither `--remote` nor `--exec` is specified, the connection mode is determined by the workspace `mode` field in configuration, falling back to auto-detection. See the [access modes how-to](../how-to/access-modes.md) for configuration steps, or the [access modes explanation](../explanation/access-modes.md) for the difference between modes.
+When neither `--remote` nor `--exec` is specified, the connection mode is determined by the workspace `mode` field in configuration, falling back to auto-detection (checks for `opencode`, then `opencode-cli` on PATH). See the [access modes how-to](../how-to/access-modes.md) for configuration steps, or the [access modes explanation](../explanation/access-modes.md) for the difference between modes.
 
 ---
 

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -64,6 +64,11 @@ func runAttach(cmd *cobra.Command, args []string) error {
 }
 
 func attachOnHost(ctx context.Context, ws *workspace.Resolved) error {
+	binary, err := config.ResolveBinary()
+	if err != nil {
+		return fmt.Errorf("resolve opencode binary: %w", err)
+	}
+
 	serverArg := fmt.Sprintf("http://localhost:%d", ws.Port)
 	args := []string{"attach", serverArg}
 
@@ -71,12 +76,12 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved) error {
 		args = append(args, "--password", password)
 	}
 
-	cmd := exec.Command("opencode", args...) //nolint:gosec // binary name is hardcoded, args are controlled
+	cmd := exec.Command(binary, args...) //nolint:gosec // binary name is from ResolveBinary, args are controlled
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	err := runCommandWithContext(ctx, cmd, func() error {
+	err = runCommandWithContext(ctx, cmd, func() error {
 		if cmd.Process == nil {
 			return nil
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -369,14 +369,29 @@ func Validate(cfg *Config) error {
 
 var lookPath = exec.LookPath
 
+// opencodeBinaries is the ordered list of binary names to search for on PATH.
+var opencodeBinaries = []string{"opencode", "opencode-cli"}
+
+// ResolveBinary returns the first opencode binary found on PATH.
+// It checks "opencode" first, then "opencode-cli" as a fallback.
+// Returns ("", error) if neither is found.
+func ResolveBinary() (string, error) {
+	for _, name := range opencodeBinaries {
+		if _, err := lookPath(name); err == nil {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("neither opencode nor opencode-cli found on PATH")
+}
+
 // ResolveMode returns the effective access mode.
 // If configured is non-empty, it is returned directly.
-// Otherwise auto-detect: returns ModeRemote if opencode is on PATH, ModeExec otherwise.
+// Otherwise auto-detect: returns ModeRemote if opencode or opencode-cli is on PATH, ModeExec otherwise.
 func ResolveMode(configured string) string {
 	if configured != "" {
 		return configured
 	}
-	if _, err := lookPath("opencode"); err == nil {
+	if _, err := ResolveBinary(); err == nil {
 		return ModeRemote
 	}
 	return ModeExec

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -377,8 +377,8 @@ var opencodeBinaries = []string{"opencode", "opencode-cli"}
 // Returns ("", error) if neither is found.
 func ResolveBinary() (string, error) {
 	for _, name := range opencodeBinaries {
-		if _, err := lookPath(name); err == nil {
-			return name, nil
+		if path, err := lookPath(name); err == nil {
+			return path, nil
 		}
 	}
 	return "", fmt.Errorf("neither opencode nor opencode-cli found on PATH")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -578,8 +578,8 @@ func TestResolveBinaryPrefersOpenCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != "opencode" {
-		t.Errorf("got %q, want %q", got, "opencode")
+	if got != "/usr/local/bin/opencode" {
+		t.Errorf("got %q, want %q", got, "/usr/local/bin/opencode")
 	}
 }
 
@@ -596,8 +596,8 @@ func TestResolveBinaryFallsBackToOpenCodeCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != "opencode-cli" {
-		t.Errorf("got %q, want %q", got, "opencode-cli")
+	if got != "/usr/local/bin/opencode-cli" {
+		t.Errorf("got %q, want %q", got, "/usr/local/bin/opencode-cli")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -535,6 +535,20 @@ func TestResolveModeWithOpenCodeOnPath(t *testing.T) {
 	}
 }
 
+func TestResolveModeWithOpenCodeCLIFallback(t *testing.T) {
+	orig := lookPath
+	t.Cleanup(func() { lookPath = orig })
+	lookPath = func(file string) (string, error) {
+		if file == "opencode-cli" {
+			return "/usr/local/bin/opencode-cli", nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	if got := ResolveMode(""); got != ModeRemote {
+		t.Errorf("got %q, want %q", got, ModeRemote)
+	}
+}
+
 func TestResolveModeWithoutOpenCode(t *testing.T) {
 	orig := lookPath
 	t.Cleanup(func() { lookPath = orig })
@@ -553,6 +567,47 @@ func TestResolveModeExplicitOverridesDetection(t *testing.T) {
 	}
 	if got := ResolveMode(ModeExec); got != ModeExec {
 		t.Errorf("explicit exec: got %q, want %q", got, ModeExec)
+	}
+}
+
+func TestResolveBinaryPrefersOpenCode(t *testing.T) {
+	orig := lookPath
+	t.Cleanup(func() { lookPath = orig })
+	lookPath = func(file string) (string, error) { return "/usr/local/bin/" + file, nil }
+	got, err := ResolveBinary()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "opencode" {
+		t.Errorf("got %q, want %q", got, "opencode")
+	}
+}
+
+func TestResolveBinaryFallsBackToOpenCodeCLI(t *testing.T) {
+	orig := lookPath
+	t.Cleanup(func() { lookPath = orig })
+	lookPath = func(file string) (string, error) {
+		if file == "opencode-cli" {
+			return "/usr/local/bin/opencode-cli", nil
+		}
+		return "", fmt.Errorf("not found")
+	}
+	got, err := ResolveBinary()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "opencode-cli" {
+		t.Errorf("got %q, want %q", got, "opencode-cli")
+	}
+}
+
+func TestResolveBinaryNeitherFound(t *testing.T) {
+	orig := lookPath
+	t.Cleanup(func() { lookPath = orig })
+	lookPath = func(file string) (string, error) { return "", fmt.Errorf("not found") }
+	_, err := ResolveBinary()
+	if err == nil {
+		t.Fatal("expected error when neither binary is found")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `ResolveBinary()` to check for `opencode` first, then `opencode-cli` as fallback
- `ResolveMode` and `attachOnHost` both use `ResolveBinary()` instead of hardcoded `opencode`
- Tests for preference order, fallback, and neither-found error case

Closes #35