### PR TITLE
feat(docker): add container healthcheck and attach health monitoring

### DIFF
--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -56,7 +56,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Added %q to workspace %q\n", targetDir, workspaceFlag)
 
-	return maybeRestartWorkspace(ws)
+	return maybeRestartWorkspace(cmd.Context(), ws)
 }
 
 func isDuplicate(paths []string, target string) bool {
@@ -68,13 +68,12 @@ func isDuplicate(paths []string, target string) bool {
 	return false
 }
 
-func maybeRestartWorkspace(ws *workspace.Resolved) error {
+func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 	compPath := filepath.Join(ComposeCacheDir(ws.Name), "docker-compose.yml")
 	if _, err := os.Stat(compPath); err != nil {
 		return nil
 	}
 
-	ctx := context.Background()
 	client := docker.NewClient(compPath, "", ws.Name)
 
 	running, err := client.IsRunning(ctx)

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/seznam/jailoc/internal/compose"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
+	"github.com/spf13/cobra"
 )
 
 var addCmd = &cobra.Command{
@@ -42,7 +42,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	ok, err := confirmBroadPath(targetDir)
+	ok, err := confirmBroadPath(cmd.Context(), targetDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -53,14 +53,27 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	defer stop()
 
 	mode := resolveFromFlags(cmd, cfg)
+	var attachErr error
 	switch mode {
 	case config.ModeExec:
 		fmt.Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
-		return attachExec(attachCtx, client)
+		attachErr = attachExec(attachCtx, client)
 	default:
 		fmt.Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
-		return attachOnHost(attachCtx, ws)
+		attachErr = attachOnHost(attachCtx, ws)
 	}
+
+	if errors.Is(attachErr, errUnhealthy) {
+		fmt.Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
+		logCtx, logCancel := context.WithTimeout(context.Background(), tailLogTimeout)
+		defer logCancel()
+		if logErr := client.TailLogs(logCtx, tailLogLines, os.Stderr); logErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
+		}
+		fmt.Fprintf(os.Stderr, "--- opencode process died inside container ---\n")
+	}
+
+	return attachErr
 }
 
 func attachOnHost(ctx context.Context, ws *workspace.Resolved) error {
@@ -113,7 +126,11 @@ func attachExec(ctx context.Context, client *docker.Client) error {
 const (
 	attachPollInterval = 500 * time.Millisecond
 	attachWaitDelay    = 2 * time.Second
+	tailLogLines       = 50
+	tailLogTimeout     = 10 * time.Second
 )
+
+var errUnhealthy = errors.New("opencode process unhealthy inside container")
 
 func startAttachWatch(parent context.Context, client *docker.Client, workspaceName string) (context.Context, func(), error) {
 	containerID, err := client.CurrentContainerID(parent)
@@ -125,7 +142,7 @@ func startAttachWatch(parent context.Context, client *docker.Client, workspaceNa
 	}
 
 	attachCtx, cancel := context.WithCancelCause(parent)
-	go monitorAttach(attachCtx, cancel, client.CurrentContainerID, containerID, attachPollInterval)
+	go monitorAttach(attachCtx, cancel, client.CurrentContainerID, client.HealthStatus, containerID, attachPollInterval)
 
 	return attachCtx, func() { cancel(nil) }, nil
 }
@@ -139,7 +156,7 @@ func attachResult(ctx context.Context, err error) error {
 	return err
 }
 
-func monitorAttach(ctx context.Context, cancel context.CancelCauseFunc, currentContainerID func(context.Context) (string, error), expectedContainerID string, interval time.Duration) {
+func monitorAttach(ctx context.Context, cancel context.CancelCauseFunc, currentContainerID func(context.Context) (string, error), healthStatus func(context.Context) (string, error), expectedContainerID string, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -162,6 +179,14 @@ func monitorAttach(ctx context.Context, cancel context.CancelCauseFunc, currentC
 			}
 			if containerID != expectedContainerID {
 				cancel(fmt.Errorf("opencode container restarted during attach"))
+				return
+			}
+			health, err := healthStatus(ctx)
+			if err != nil {
+				continue // transient health check failure — ignore
+			}
+			if health == "unhealthy" {
+				cancel(errUnhealthy)
 				return
 			}
 		}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -65,7 +65,7 @@ func runAttach(cmd *cobra.Command, args []string) error {
 
 	if errors.Is(attachErr, errUnhealthy) {
 		fmt.Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
-		logCtx, logCancel := context.WithTimeout(context.Background(), tailLogTimeout)
+		logCtx, logCancel := context.WithTimeout(ctx, tailLogTimeout)
 		defer logCancel()
 		if logErr := client.TailLogs(logCtx, tailLogLines, os.Stderr); logErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -70,7 +70,7 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		if logErr := client.TailLogs(logCtx, tailLogLines, os.Stderr); logErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
 		}
-		fmt.Fprintf(os.Stderr, "--- opencode process died inside container ---\n")
+		fmt.Fprintf(os.Stderr, "--- container reported unhealthy; see logs above ---\n")
 	}
 
 	return attachErr

--- a/internal/cmd/attach_test.go
+++ b/internal/cmd/attach_test.go
@@ -13,6 +13,8 @@ import (
 func TestMonitorAttach(t *testing.T) {
 	t.Parallel()
 
+	noHealth := func(context.Context) (string, error) { return "", nil }
+
 	t.Run("cancels when container stops", func(t *testing.T) {
 		t.Parallel()
 
@@ -21,7 +23,7 @@ func TestMonitorAttach(t *testing.T) {
 
 		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
 			return "", nil
-		}, "original", time.Millisecond)
+		}, noHealth, "original", time.Millisecond)
 
 		cause := waitForCause(t, ctx)
 		if cause == nil || !strings.Contains(cause.Error(), "stopped") {
@@ -37,7 +39,7 @@ func TestMonitorAttach(t *testing.T) {
 
 		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
 			return "replacement", nil
-		}, "original", time.Millisecond)
+		}, noHealth, "original", time.Millisecond)
 
 		cause := waitForCause(t, ctx)
 		if cause == nil || !strings.Contains(cause.Error(), "restarted") {
@@ -53,12 +55,88 @@ func TestMonitorAttach(t *testing.T) {
 
 		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
 			return "", errors.New("boom")
-		}, "original", time.Millisecond)
+		}, noHealth, "original", time.Millisecond)
 
 		cause := waitForCause(t, ctx)
 		if cause == nil || !strings.Contains(cause.Error(), "monitor opencode container") {
 			t.Fatalf("got cause %v, want monitor error", cause)
 		}
+	})
+
+	t.Run("cancels when unhealthy", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
+			return "original", nil
+		}, func(context.Context) (string, error) {
+			return "unhealthy", nil
+		}, "original", time.Millisecond)
+
+		cause := waitForCause(t, ctx)
+		if !errors.Is(cause, errUnhealthy) {
+			t.Fatalf("got cause %v, want errUnhealthy", cause)
+		}
+	})
+
+	t.Run("continues when healthy", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
+			return "original", nil
+		}, func(context.Context) (string, error) {
+			return "healthy", nil
+		}, "original", time.Millisecond)
+
+		assertNotCanceled(t, ctx, 50*time.Millisecond)
+	})
+
+	t.Run("continues when no healthcheck", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
+			return "original", nil
+		}, noHealth, "original", time.Millisecond)
+
+		assertNotCanceled(t, ctx, 50*time.Millisecond)
+	})
+
+	t.Run("continues when starting", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
+			return "original", nil
+		}, func(context.Context) (string, error) {
+			return "starting", nil
+		}, "original", time.Millisecond)
+
+		assertNotCanceled(t, ctx, 50*time.Millisecond)
+	})
+
+	t.Run("ignores transient health errors", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+
+		go monitorAttach(ctx, cancel, func(context.Context) (string, error) {
+			return "original", nil
+		}, func(context.Context) (string, error) {
+			return "", errors.New("transient failure")
+		}, "original", time.Millisecond)
+
+		assertNotCanceled(t, ctx, 50*time.Millisecond)
 	})
 }
 
@@ -127,5 +205,15 @@ func waitForCause(t *testing.T, ctx context.Context) error {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timed out waiting for context cancellation")
 		return nil
+	}
+}
+
+func assertNotCanceled(t *testing.T, ctx context.Context, wait time.Duration) {
+	t.Helper()
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("context was canceled unexpectedly: %v", context.Cause(ctx))
+	case <-time.After(wait):
 	}
 }

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"sort"
 
-	"github.com/spf13/cobra"
 	"github.com/seznam/jailoc/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var configCmd = &cobra.Command{
@@ -17,7 +16,7 @@ var configCmd = &cobra.Command{
 }
 
 func runConfig(cmd *cobra.Command, args []string) error {
-	ctx := context.Background()
+	ctx := cmd.Context()
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -1,15 +1,14 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
+	"github.com/spf13/cobra"
 )
 
 var downCmd = &cobra.Command{
@@ -41,14 +40,15 @@ func runDown(cmd *cobra.Command, args []string) error {
 	}
 
 	client := docker.NewClient(composePath, "", ws.Name)
-	running, err := client.IsRunning(context.Background())
+	ctx := cmd.Context()
+	running, err := client.IsRunning(ctx)
 	if err != nil || !running {
 		fmt.Printf("Workspace %s is not running\n", ws.Name)
 		return nil
 	}
 
 	fmt.Printf("Stopping workspace %s...\n", ws.Name)
-	if err := client.Down(context.Background()); err != nil {
+	if err := client.Down(ctx); err != nil {
 		return fmt.Errorf("stop workspace: %w", err)
 	}
 

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +21,7 @@ var logsCmd = &cobra.Command{
 }
 
 func runLogs(cmd *cobra.Command, args []string) error {
-	ctx := context.Background()
+	ctx := cmd.Context()
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
+	"github.com/spf13/cobra"
 )
 
 var followLogs bool
@@ -42,7 +42,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 
 	composePath := filepath.Join(ComposeCacheDir(ws.Name), "docker-compose.yml")
 
-	// Check if compose file exists (workspace running)
+	// Check if compose file exists (workspace was started at some point)
 	if _, err := os.Stat(composePath); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("workspace %q is not running; start it with 'jailoc up'", ws.Name)
@@ -51,16 +51,6 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	client := docker.NewClient(composePath, "", ws.Name)
-
-	// Check if workspace is actually running
-	running, err := client.IsRunning(ctx)
-	if err != nil {
-		return fmt.Errorf("check if workspace is running: %w", err)
-	}
-
-	if !running {
-		return fmt.Errorf("workspace %q is not running; start it with 'jailoc up'", ws.Name)
-	}
 
 	// Stream logs
 	if err := client.Logs(ctx, followLogs, os.Stdout); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -213,9 +213,10 @@ func readLineCtx(ctx context.Context) (string, error) {
 
 	select {
 	case <-ctx.Done():
-		_ = os.Stdin.SetReadDeadline(time.Now())
-		<-ch
-		_ = os.Stdin.SetReadDeadline(time.Time{})
+		if err := os.Stdin.SetReadDeadline(time.Now()); err == nil {
+			<-ch
+			_ = os.Stdin.SetReadDeadline(time.Time{})
+		}
 		return "", ctx.Err()
 	case r := <-ch:
 		return r.line, r.err

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,10 +12,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
+	"github.com/spf13/cobra"
 )
 
 var workspaceFlag string
@@ -46,8 +46,7 @@ var rootCmd = &cobra.Command{
 
 		if !workspace.MatchesCWD(ws, targetPath) {
 			fmt.Printf("Path %s is not in workspace %s. Add it? [y/N]: ", targetPath, ws.Name)
-			reader := bufio.NewReader(os.Stdin)
-			answer, err := reader.ReadString('\n')
+			answer, err := readLineCtx(ctx)
 			if err != nil {
 				return fmt.Errorf("read add-to-workspace prompt response: %w", err)
 			}
@@ -57,7 +56,7 @@ var rootCmd = &cobra.Command{
 				return nil
 			}
 
-			ok, err := confirmBroadPath(targetPath)
+			ok, err := confirmBroadPath(ctx, targetPath)
 			if err != nil {
 				return err
 			}
@@ -179,7 +178,7 @@ func isBroadPath(path string) bool {
 	return path == home
 }
 
-func confirmBroadPath(path string) (bool, error) {
+func confirmBroadPath(ctx context.Context, path string) (bool, error) {
 	if !isBroadPath(path) {
 		return true, nil
 	}
@@ -187,14 +186,39 @@ func confirmBroadPath(path string) (bool, error) {
 	fmt.Printf("WARNING: %q is a very broad path — this will mount your entire directory tree into the container.\n", path)
 	fmt.Print("Are you sure? [y/N]: ")
 
-	reader := bufio.NewReader(os.Stdin)
-	answer, err := reader.ReadString('\n')
+	answer, err := readLineCtx(ctx)
 	if err != nil {
 		return false, fmt.Errorf("read broad-path confirmation: %w", err)
 	}
 
 	trimmed := strings.ToLower(strings.TrimSpace(answer))
 	return trimmed == "y" || trimmed == "yes", nil
+}
+
+// readLineCtx reads a line from stdin, returning ctx.Err() on cancellation.
+// Uses SetReadDeadline to interrupt the blocked read — no goroutine leak.
+// Pattern from encoredev/encore (cli/internal/login/deviceauth.go).
+func readLineCtx(ctx context.Context) (string, error) {
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		ch <- result{line, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		os.Stdin.SetReadDeadline(time.Now())
+		<-ch
+		os.Stdin.SetReadDeadline(time.Time{})
+		return "", ctx.Err()
+	case r := <-ch:
+		return r.line, r.err
+	}
 }
 
 // resolveFromFlags returns the effective access mode based on CLI flags and config.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -95,7 +95,7 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}
 			fmt.Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
-			if err := waitForReady(ctx, ws.Port); err != nil {
+			if err := waitForReady(ctx, ws.Port, client); err != nil {
 				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 			}
 		}
@@ -250,26 +250,40 @@ const (
 	readyPollTimeout  = 60 * time.Second
 )
 
-func waitForReady(ctx context.Context, port int) error {
+func waitForReady(ctx context.Context, port int, dc *docker.Client) error {
 	url := fmt.Sprintf("http://localhost:%d", port)
 
 	ctx, cancel := context.WithTimeout(ctx, readyPollTimeout)
 	defer cancel()
 
-	client := &http.Client{Timeout: 2 * time.Second}
+	httpClient := &http.Client{Timeout: 2 * time.Second}
 	ticker := time.NewTicker(readyPollInterval)
 	defer ticker.Stop()
+
+	// Check container state every ~1s (every 5th tick at 200ms interval)
+	// to detect early exits without waiting for the full 60s timeout.
+	const stateCheckInterval = 5
+	tick := 0
 
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("timed out after %s waiting for %s", readyPollTimeout, url)
 		case <-ticker.C:
+			tick++
+
+			if tick%stateCheckInterval == 0 {
+				state, exitCode, err := dc.ContainerState(ctx)
+				if err == nil && state == "exited" {
+					return fmt.Errorf("container exited with code %d before becoming ready", exitCode)
+				}
+			}
+
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 			if err != nil {
 				return fmt.Errorf("create readiness request: %w", err)
 			}
-			resp, err := client.Do(req) //nolint:gosec // URL is localhost with controlled port
+			resp, err := httpClient.Do(req) //nolint:gosec // URL is localhost with controlled port
 			if err != nil {
 				continue
 			}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -212,9 +212,9 @@ func readLineCtx(ctx context.Context) (string, error) {
 
 	select {
 	case <-ctx.Done():
-		os.Stdin.SetReadDeadline(time.Now())
+		_ = os.Stdin.SetReadDeadline(time.Now())
 		<-ch
-		os.Stdin.SetReadDeadline(time.Time{})
+		_ = os.Stdin.SetReadDeadline(time.Time{})
 		return "", ctx.Err()
 	case r := <-ch:
 		return r.line, r.err

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,9 +23,10 @@ var appVersion string
 var remoteFlag, execFlag bool
 
 var rootCmd = &cobra.Command{
-	Use:   "jailoc [path]",
-	Short: "Manage sandboxed OpenCode Docker environments",
-	Args:  cobra.MaximumNArgs(1),
+	Use:          "jailoc [path]",
+	Short:        "Manage sandboxed OpenCode Docker environments",
+	SilenceUsage: true,
+	Args:         cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -260,25 +261,16 @@ func waitForReady(ctx context.Context, port int, dc *docker.Client) error {
 	ticker := time.NewTicker(readyPollInterval)
 	defer ticker.Stop()
 
-	// Check container state every ~1s (every 5th tick at 200ms interval)
-	// to detect early exits without waiting for the full 60s timeout.
-	const stateCheckInterval = 5
-	tick := 0
-
 	for {
+		state, exitCode, err := dc.ContainerState(ctx)
+		if err == nil && state == "exited" {
+			return fmt.Errorf("container exited with code %d before becoming ready", exitCode)
+		}
+
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("timed out after %s waiting for %s", readyPollTimeout, url)
 		case <-ticker.C:
-			tick++
-
-			if tick%stateCheckInterval == 0 {
-				state, exitCode, err := dc.ContainerState(ctx)
-				if err == nil && state == "exited" {
-					return fmt.Errorf("container exited with code %d before becoming ready", exitCode)
-				}
-			}
-
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 			if err != nil {
 				return fmt.Errorf("create readiness request: %w", err)

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,7 +40,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	client := docker.NewClient(composePath, "", ws.Name)
-	running, err := client.IsRunning(context.Background())
+
+	ctx := cmd.Context()
+	running, err := client.IsRunning(ctx)
 	if err != nil {
 		return fmt.Errorf("check running status: %w", err)
 	}
@@ -54,7 +55,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Workspace: %s\n", ws.Name)
 	fmt.Printf("Port:      %d\n", ws.Port)
 
-	health, err := client.HealthStatus(context.Background())
+	health, err := client.HealthStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("check health status: %w", err)
 	}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -40,14 +40,14 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	client := docker.NewClient(composePath, "", ws.Name)
-
 	ctx := cmd.Context()
-	running, err := client.IsRunning(ctx)
+
+	state, exitCode, err := client.ContainerState(ctx)
 	if err != nil {
-		return fmt.Errorf("check running status: %w", err)
+		return fmt.Errorf("check container state: %w", err)
 	}
 
-	if !running {
+	if state == "" {
 		fmt.Printf("Workspace %s is not running\n", ws.Name)
 		return nil
 	}
@@ -55,19 +55,27 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Workspace: %s\n", ws.Name)
 	fmt.Printf("Port:      %d\n", ws.Port)
 
-	health, err := client.HealthStatus(ctx)
-	if err != nil {
-		return fmt.Errorf("check health status: %w", err)
+	switch state {
+	case "running":
+		health, err := client.HealthStatus(ctx)
+		if err != nil {
+			return fmt.Errorf("check health status: %w", err)
+		}
+
+		switch health {
+		case "unhealthy":
+			fmt.Printf("Status:    running (unhealthy)\n")
+		case "starting":
+			fmt.Printf("Status:    running (starting)\n")
+		default:
+			fmt.Printf("Status:    running\n")
+		}
+	case "exited":
+		fmt.Printf("Status:    exited (code %d)\n", exitCode)
+	default:
+		fmt.Printf("Status:    %s\n", state)
 	}
 
-	switch health {
-	case "unhealthy":
-		fmt.Printf("Status:    running (unhealthy)\n")
-	case "starting":
-		fmt.Printf("Status:    running (starting)\n")
-	default:
-		fmt.Printf("Status:    running\n")
-	}
 	return nil
 }
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/spf13/cobra"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
+	"github.com/spf13/cobra"
 )
 
 var statusCmd = &cobra.Command{
@@ -53,7 +53,20 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Workspace: %s\n", ws.Name)
 	fmt.Printf("Port:      %d\n", ws.Port)
-	fmt.Printf("Status:    running\n")
+
+	health, err := client.HealthStatus(context.Background())
+	if err != nil {
+		return fmt.Errorf("check health status: %w", err)
+	}
+
+	switch health {
+	case "unhealthy":
+		fmt.Printf("Status:    running (unhealthy)\n")
+	case "starting":
+		fmt.Printf("Status:    running (starting)\n")
+	default:
+		fmt.Printf("Status:    running\n")
+	}
 	return nil
 }
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -34,6 +34,9 @@ func TestGenerateComposeSinglePath(t *testing.T) {
 	assertContains(t, rendered, "opencode-data-alpha")
 	assertContains(t, rendered, "opencode-cache-alpha")
 	assertContains(t, rendered, "working_dir: /Users/test/work/project")
+	assertContains(t, rendered, "healthcheck:")
+	assertContains(t, rendered, "$$OPENCODE_SERVER_PASSWORD")
+	assertContains(t, rendered, "/global/health")
 }
 
 func TestGenerateComposeMultiplePaths(t *testing.T) {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -126,6 +126,22 @@ func (c *Client) HealthStatus(ctx context.Context) (string, error) {
 	return string(container.Health), nil
 }
 
+// ContainerState returns the state and exit code of the opencode container,
+// regardless of whether it is running. Returns empty state if no container exists.
+func (c *Client) ContainerState(ctx context.Context) (state string, exitCode int, err error) {
+	if err := c.initComposeSvc(); err != nil {
+		return "", 0, err
+	}
+
+	containers, err := c.svc.Ps(ctx, "jailoc-"+c.workspace, api.PsOptions{All: true})
+	if err != nil {
+		return "", 0, fmt.Errorf("compose ps for workspace %q: %w", c.workspace, err)
+	}
+
+	ct := anyOpencodeContainer(containers)
+	return string(ct.State), ct.ExitCode, nil
+}
+
 func (c *Client) opencodeContainer(ctx context.Context) (api.ContainerSummary, error) {
 	if err := c.initComposeSvc(); err != nil {
 		return api.ContainerSummary{}, err
@@ -148,6 +164,39 @@ func currentOpencodeContainer(containers []api.ContainerSummary) api.ContainerSu
 		}
 
 		if selected.ID == "" || ct.Created > selected.Created {
+			selected = ct
+		}
+	}
+
+	return selected
+}
+
+// anyOpencodeContainer returns the opencode container regardless of state.
+// It prefers running containers; if none are running, it returns the most recently created one.
+func anyOpencodeContainer(containers []api.ContainerSummary) api.ContainerSummary {
+	var selected api.ContainerSummary
+
+	for _, ct := range containers {
+		if ct.Service != "opencode" {
+			continue
+		}
+
+		if selected.ID == "" {
+			selected = ct
+			continue
+		}
+
+		// Prefer running over non-running.
+		if ct.State == "running" && selected.State != "running" {
+			selected = ct
+			continue
+		}
+		if ct.State != "running" && selected.State == "running" {
+			continue
+		}
+
+		// Same state class — prefer newest.
+		if ct.Created > selected.Created {
 			selected = ct
 		}
 	}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -116,6 +117,15 @@ func (c *Client) CurrentContainerID(ctx context.Context) (string, error) {
 	return container.ID, nil
 }
 
+func (c *Client) HealthStatus(ctx context.Context) (string, error) {
+	container, err := c.opencodeContainer(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return string(container.Health), nil
+}
+
 func (c *Client) opencodeContainer(ctx context.Context) (api.ContainerSummary, error) {
 	if err := c.initComposeSvc(); err != nil {
 		return api.ContainerSummary{}, err
@@ -165,6 +175,19 @@ func (c *Client) Logs(ctx context.Context, follow bool, w io.Writer) error {
 	consumer := &writerLogConsumer{w: w}
 	if err := c.svc.Logs(ctx, "jailoc-"+c.workspace, consumer, api.LogOptions{Follow: follow}); err != nil {
 		return fmt.Errorf("compose logs for workspace %q: %w", c.workspace, err)
+	}
+
+	return nil
+}
+
+func (c *Client) TailLogs(ctx context.Context, n int, w io.Writer) error {
+	if err := c.initComposeSvc(); err != nil {
+		return err
+	}
+
+	consumer := &writerLogConsumer{w: w}
+	if err := c.svc.Logs(ctx, "jailoc-"+c.workspace, consumer, api.LogOptions{Tail: strconv.Itoa(n)}); err != nil {
+		return fmt.Errorf("tail compose logs for workspace %q: %w", c.workspace, err)
 	}
 
 	return nil

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -151,6 +151,64 @@ func TestCurrentOpencodeContainer(t *testing.T) {
 	})
 }
 
+func TestAnyOpencodeContainer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers running over exited", func(t *testing.T) {
+		t.Parallel()
+
+		got := anyOpencodeContainer([]api.ContainerSummary{
+			{ID: "exited", Service: "opencode", State: containertypes.StateExited, Created: 200, ExitCode: 1},
+			{ID: "running", Service: "opencode", State: containertypes.StateRunning, Created: 100},
+		})
+
+		if got.ID != "running" {
+			t.Fatalf("got container %q, want %q", got.ID, "running")
+		}
+	})
+
+	t.Run("returns exited container when no running exists", func(t *testing.T) {
+		t.Parallel()
+
+		got := anyOpencodeContainer([]api.ContainerSummary{
+			{ID: "dind", Service: "dind", State: containertypes.StateRunning, Created: 300},
+			{ID: "exited", Service: "opencode", State: containertypes.StateExited, Created: 200, ExitCode: 1},
+		})
+
+		if got.ID != "exited" {
+			t.Fatalf("got container %q, want %q", got.ID, "exited")
+		}
+		if got.ExitCode != 1 {
+			t.Fatalf("got exit code %d, want 1", got.ExitCode)
+		}
+	})
+
+	t.Run("selects newest among same state", func(t *testing.T) {
+		t.Parallel()
+
+		got := anyOpencodeContainer([]api.ContainerSummary{
+			{ID: "old-exit", Service: "opencode", State: containertypes.StateExited, Created: 100},
+			{ID: "new-exit", Service: "opencode", State: containertypes.StateExited, Created: 200},
+		})
+
+		if got.ID != "new-exit" {
+			t.Fatalf("got container %q, want %q", got.ID, "new-exit")
+		}
+	})
+
+	t.Run("returns zero value when no opencode container exists", func(t *testing.T) {
+		t.Parallel()
+
+		got := anyOpencodeContainer([]api.ContainerSummary{
+			{ID: "dind", Service: "dind", State: containertypes.StateRunning, Created: 100},
+		})
+
+		if got.ID != "" {
+			t.Fatalf("got container %q, want empty ID", got.ID)
+		}
+	})
+}
+
 func TestBuildPresetImageEmptyContent(t *testing.T) {
 	t.Parallel()
 	_, err := buildPresetImage(context.Background(), nil, nil)

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -123,6 +123,32 @@ func TestCurrentOpencodeContainer(t *testing.T) {
 			t.Fatalf("got container %q, want empty ID", got.ID)
 		}
 	})
+
+	t.Run("preserves health field from selected container", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name   string
+			health containertypes.HealthStatus
+		}{
+			{"healthy", containertypes.Healthy},
+			{"unhealthy", containertypes.Unhealthy},
+			{"no healthcheck", ""},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				got := currentOpencodeContainer([]api.ContainerSummary{
+					{ID: "oc", Service: "opencode", State: containertypes.StateRunning, Created: 100, Health: tt.health},
+				})
+
+				if got.Health != tt.health {
+					t.Fatalf("got health %q, want %q", got.Health, tt.health)
+				}
+			})
+		}
+	})
 }
 
 func TestBuildPresetImageEmptyContent(t *testing.T) {

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -54,7 +54,7 @@ services:
     working_dir: {{index .Paths 0}}
 {{- end}}
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf -u opencode:$$OPENCODE_SERVER_PASSWORD http://localhost:4096/global/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf -u \"opencode:$$OPENCODE_SERVER_PASSWORD\" http://localhost:4096/global/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -53,6 +53,12 @@ services:
 {{- if .Paths}}
     working_dir: {{index .Paths 0}}
 {{- end}}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -u opencode:$$OPENCODE_SERVER_PASSWORD http://localhost:4096/global/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   dind:
     image: docker:dind


### PR DESCRIPTION
## Summary

- Add Docker healthcheck to the `opencode` compose service — probes `GET /global/health` with Basic Auth via `curl` (CMD-SHELL, `$$` escaping for Compose variable substitution)
- `jailoc status` now shows `running (unhealthy)` / `running (starting)` when healthcheck reports non-healthy state
- `jailoc attach` detects unhealthy containers via `monitorAttach` polling, tails last 50 log lines to stderr before exiting

Closes #22, closes #36