### PR TITLE
fix(version): use debug.ReadBuildInfo as fallback for go install

### DIFF
--- a/cmd/jailoc/main.go
+++ b/cmd/jailoc/main.go
@@ -22,6 +22,7 @@ func main() {
 			if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
 				version = bi.Main.Version
 			}
+			var modified bool
 			for _, s := range bi.Settings {
 				switch s.Key {
 				case "vcs.revision":
@@ -30,7 +31,12 @@ func main() {
 					}
 				case "vcs.time":
 					date = s.Value
+				case "vcs.modified":
+					modified = s.Value == "true"
 				}
+			}
+			if modified {
+				commit += "-dirty"
 			}
 		}
 	}

--- a/cmd/jailoc/main.go
+++ b/cmd/jailoc/main.go
@@ -26,8 +26,10 @@ func main() {
 			for _, s := range bi.Settings {
 				switch s.Key {
 				case "vcs.revision":
-					if len(s.Value) >= 12 {
+					if len(s.Value) > 12 {
 						commit = s.Value[:12]
+					} else if s.Value != "" {
+						commit = s.Value
 					}
 				case "vcs.time":
 					date = s.Value

--- a/cmd/jailoc/main.go
+++ b/cmd/jailoc/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/seznam/jailoc/internal/cmd"
 )
@@ -13,6 +14,27 @@ var (
 )
 
 func main() {
+	// When installed via "go install", ldflags are not set and version stays "dev".
+	// Fall back to build info embedded by the Go toolchain since 1.18.
+	// See https://pkg.go.dev/runtime/debug#ReadBuildInfo
+	if version == "dev" {
+		if bi, ok := debug.ReadBuildInfo(); ok {
+			if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+				version = bi.Main.Version
+			}
+			for _, s := range bi.Settings {
+				switch s.Key {
+				case "vcs.revision":
+					if len(s.Value) >= 12 {
+						commit = s.Value[:12]
+					}
+				case "vcs.time":
+					date = s.Value
+				}
+			}
+		}
+	}
+
 	if err := cmd.Execute(version, commit, date); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary

- `jailoc --version` shows `dev (commit: none, built: unknown)` when installed via `go install` because ldflags aren't set
- Fall back to `runtime/debug.ReadBuildInfo()` to extract module version, VCS revision, and build time embedded by the Go toolchain
- GoReleaser builds are unaffected — ldflags override the `"dev"` default before the fallback runs