### PR TITLE
feat(cmd): add colored terminal output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/docker/cli v29.2.1+incompatible
 	github.com/docker/compose/v5 v5.1.1
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/fatih/color v1.19.0
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/moby/api v1.54.0
+	github.com/moby/moby/client v0.3.0
 	github.com/moby/term v0.5.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.41.0
@@ -62,13 +64,14 @@ require (
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/moby/buildkit v0.27.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/moby/client v0.3.0 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/capability v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJtLmY22n99HaZTz+r2Z51xUPi01m3wg=
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
+github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsevents v0.2.0 h1:BRlvlqjvNTfogHfeBOFvSC9N0Ddy+wzQCQukyoD7o/c=
@@ -205,6 +207,10 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
@@ -409,6 +415,7 @@ golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -39,7 +39,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if isDuplicate(ws.Paths, targetDir) {
-		color.New(color.FgYellow).Printf("Path %q is already in workspace %q\n", targetDir, ws.Name)
+		_, _ = color.New(color.FgYellow).Printf("Path %q is already in workspace %q\n", targetDir, ws.Name)
 		return nil
 	}
 
@@ -55,7 +55,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("add path to config: %w", err)
 	}
 
-	color.New(color.FgGreen).Printf("Added %q to workspace %q\n", targetDir, workspaceFlag)
+	_, _ = color.New(color.FgGreen).Printf("Added %q to workspace %q\n", targetDir, workspaceFlag)
 
 	return maybeRestartWorkspace(cmd.Context(), ws)
 }
@@ -116,12 +116,12 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return fmt.Errorf("regenerate compose file: %w", err)
 	}
 
-	color.New(color.FgCyan).Printf("Restarting workspace %s with updated mounts...\n", ws.Name)
+	_, _ = color.New(color.FgCyan).Printf("Restarting workspace %s with updated mounts...\n", ws.Name)
 	if err := client.Up(ctx); err != nil {
 		return fmt.Errorf("restart workspace: %w", err)
 	}
 
-	color.New(color.FgGreen).Printf("Workspace %q restarted with updated mounts\n", ws.Name)
+	_, _ = color.New(color.FgGreen).Printf("Workspace %q restarted with updated mounts\n", ws.Name)
 	return nil
 }
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/compose"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
@@ -38,7 +39,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if isDuplicate(ws.Paths, targetDir) {
-		fmt.Printf("Path %q is already in workspace %q\n", targetDir, ws.Name)
+		color.New(color.FgYellow).Printf("Path %q is already in workspace %q\n", targetDir, ws.Name)
 		return nil
 	}
 
@@ -54,7 +55,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("add path to config: %w", err)
 	}
 
-	fmt.Printf("Added %q to workspace %q\n", targetDir, workspaceFlag)
+	color.New(color.FgGreen).Printf("Added %q to workspace %q\n", targetDir, workspaceFlag)
 
 	return maybeRestartWorkspace(cmd.Context(), ws)
 }
@@ -115,12 +116,12 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return fmt.Errorf("regenerate compose file: %w", err)
 	}
 
-	fmt.Printf("Restarting workspace %s with updated mounts...\n", ws.Name)
+	color.New(color.FgCyan).Printf("Restarting workspace %s with updated mounts...\n", ws.Name)
 	if err := client.Up(ctx); err != nil {
 		return fmt.Errorf("restart workspace: %w", err)
 	}
 
-	fmt.Printf("Workspace %q restarted with updated mounts\n", ws.Name)
+	color.New(color.FgGreen).Printf("Workspace %q restarted with updated mounts\n", ws.Name)
 	return nil
 }
 

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
@@ -56,21 +57,21 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	var attachErr error
 	switch mode {
 	case config.ModeExec:
-		fmt.Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
+		color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
 		attachErr = attachExec(attachCtx, client)
 	default:
-		fmt.Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
+		color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
 		attachErr = attachOnHost(attachCtx, ws)
 	}
 
 	if errors.Is(attachErr, errUnhealthy) {
-		fmt.Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
+		color.New(color.FgCyan).Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
 		logCtx, logCancel := context.WithTimeout(ctx, tailLogTimeout)
 		defer logCancel()
 		if logErr := client.TailLogs(logCtx, tailLogLines, os.Stderr); logErr != nil {
-			fmt.Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
+			color.New(color.FgYellow).Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
 		}
-		fmt.Fprintf(os.Stderr, "--- container reported unhealthy; see logs above ---\n")
+		color.New(color.FgRed).Fprintf(os.Stderr, "--- container reported unhealthy; see logs above ---\n")
 	}
 
 	return attachErr

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -57,21 +57,21 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	var attachErr error
 	switch mode {
 	case config.ModeExec:
-		color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
+		_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
 		attachErr = attachExec(attachCtx, client)
 	default:
-		color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
+		_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
 		attachErr = attachOnHost(attachCtx, ws)
 	}
 
 	if errors.Is(attachErr, errUnhealthy) {
-		color.New(color.FgCyan).Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
 		logCtx, logCancel := context.WithTimeout(ctx, tailLogTimeout)
 		defer logCancel()
 		if logErr := client.TailLogs(logCtx, tailLogLines, os.Stderr); logErr != nil {
-			color.New(color.FgYellow).Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
+			_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
 		}
-		color.New(color.FgRed).Fprintf(os.Stderr, "--- container reported unhealthy; see logs above ---\n")
+		_, _ = color.New(color.FgRed).Fprintf(os.Stderr, "--- container reported unhealthy; see logs above ---\n")
 	}
 
 	return attachErr

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -52,72 +52,72 @@ func runConfig(cmd *cobra.Command, args []string) error {
 
 	_, _ = color.New(color.FgCyan, color.Bold).Fprintf(os.Stdout, "Defaults Allowed Hosts:\n")
 	if len(cfg.Defaults.AllowedHosts) == 0 {
-		_, _ = fmt.Fprintf(os.Stdout, "  (none)\n")
+		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, host := range cfg.Defaults.AllowedHosts {
-			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", host)
+			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", host)
 		}
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "Defaults Allowed Networks:\n")
+	_, _ = color.New(color.FgCyan, color.Bold).Fprintf(os.Stdout, "Defaults Allowed Networks:\n")
 	if len(cfg.Defaults.AllowedNetworks) == 0 {
-		_, _ = fmt.Fprintf(os.Stdout, "  (none)\n")
+		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, network := range cfg.Defaults.AllowedNetworks {
-			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", network)
+			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", network)
 		}
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "Defaults Env:\n")
+	_, _ = color.New(color.FgCyan, color.Bold).Fprintf(os.Stdout, "Defaults Env:\n")
 	if len(cfg.Defaults.Env) == 0 {
-		_, _ = fmt.Fprintf(os.Stdout, "  (none)\n")
+		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, env := range cfg.Defaults.Env {
-			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", env)
+			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", env)
 		}
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "Defaults Env Files:\n")
+	_, _ = color.New(color.FgCyan, color.Bold).Fprintf(os.Stdout, "Defaults Env Files:\n")
 	if len(cfg.Defaults.EnvFile) == 0 {
-		_, _ = fmt.Fprintf(os.Stdout, "  (none)\n")
+		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, f := range cfg.Defaults.EnvFile {
-			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", f)
+			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", f)
 		}
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "\n")
+	_, _ = color.New(color.Reset).Fprintf(os.Stdout, "\n")
 
 	// Print each workspace
 	for _, name := range names {
 		ws := cfg.Workspaces[name]
 
-		_, _ = fmt.Fprintf(os.Stdout, "Workspace: %s\n", name)
+		_, _ = color.New(color.FgCyan, color.Bold).Fprintf(os.Stdout, "Workspace: %s\n", name)
 
-		_, _ = fmt.Fprintf(os.Stdout, "  Paths:\n")
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Paths:\n")
 		if len(ws.Paths) == 0 {
-			_, _ = fmt.Fprintf(os.Stdout, "    (none)\n")
+			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, path := range ws.Paths {
-				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", path)
+				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", path)
 			}
 		}
 
-		_, _ = fmt.Fprintf(os.Stdout, "  Allowed Hosts:\n")
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Allowed Hosts:\n")
 		if len(ws.AllowedHosts) == 0 {
-			_, _ = fmt.Fprintf(os.Stdout, "    (none)\n")
+			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, host := range ws.AllowedHosts {
-				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", host)
+				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", host)
 			}
 		}
 
-		_, _ = fmt.Fprintf(os.Stdout, "  Allowed Networks:\n")
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Allowed Networks:\n")
 		if len(ws.AllowedNetworks) == 0 {
-			_, _ = fmt.Fprintf(os.Stdout, "    (none)\n")
+			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, network := range ws.AllowedNetworks {
-				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", network)
+				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", network)
 			}
 		}
 
@@ -125,39 +125,39 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		if buildContext == "" {
 			buildContext = "(none)"
 		}
-		_, _ = fmt.Fprintf(os.Stdout, "  Build Context: %s\n", buildContext)
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Build Context: %s\n", buildContext)
 
 		wsImage := ws.Image
 		if wsImage == "" {
 			wsImage = "(not set)"
 		}
-		_, _ = fmt.Fprintf(os.Stdout, "  Image: %s\n", wsImage)
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Image: %s\n", wsImage)
 
 		wsDockerfile := ws.Dockerfile
 		if wsDockerfile == "" {
 			wsDockerfile = "(not set)"
 		}
-		_, _ = fmt.Fprintf(os.Stdout, "  Dockerfile: %s\n", wsDockerfile)
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Dockerfile: %s\n", wsDockerfile)
 
-		_, _ = fmt.Fprintf(os.Stdout, "  Env:\n")
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Env:\n")
 		if len(ws.Env) == 0 {
-			_, _ = fmt.Fprintf(os.Stdout, "    (none)\n")
+			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, env := range ws.Env {
-				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", env)
+				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", env)
 			}
 		}
 
-		_, _ = fmt.Fprintf(os.Stdout, "  Env Files:\n")
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Env Files:\n")
 		if len(ws.EnvFile) == 0 {
-			_, _ = fmt.Fprintf(os.Stdout, "    (none)\n")
+			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, f := range ws.EnvFile {
-				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", f)
+				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", f)
 			}
 		}
 
-		_, _ = fmt.Fprintf(os.Stdout, "\n")
+		_, _ = color.New(color.Reset).Fprintf(os.Stdout, "\n")
 	}
 
 	_ = ctx // silence unused variable warning

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -55,7 +55,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, host := range cfg.Defaults.AllowedHosts {
-			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", host)
+			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", host)
 		}
 	}
 
@@ -64,7 +64,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, network := range cfg.Defaults.AllowedNetworks {
-			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", network)
+			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", network)
 		}
 	}
 
@@ -73,7 +73,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, env := range cfg.Defaults.Env {
-			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", env)
+			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", env)
 		}
 	}
 
@@ -82,11 +82,11 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "  (none)\n")
 	} else {
 		for _, f := range cfg.Defaults.EnvFile {
-			_, _ = color.New(color.Reset).Fprintf(os.Stdout, "  - %s\n", f)
+			_, _ = fmt.Fprintf(os.Stdout, "  - %s\n", f)
 		}
 	}
 
-	_, _ = color.New(color.Reset).Fprintf(os.Stdout, "\n")
+	_, _ = fmt.Fprintf(os.Stdout, "\n")
 
 	// Print each workspace
 	for _, name := range names {
@@ -99,7 +99,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, path := range ws.Paths {
-				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", path)
+				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", path)
 			}
 		}
 
@@ -108,7 +108,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, host := range ws.AllowedHosts {
-				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", host)
+				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", host)
 			}
 		}
 
@@ -117,7 +117,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, network := range ws.AllowedNetworks {
-				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", network)
+				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", network)
 			}
 		}
 
@@ -144,7 +144,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, env := range ws.Env {
-				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", env)
+				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", env)
 			}
 		}
 
@@ -153,11 +153,11 @@ func runConfig(cmd *cobra.Command, args []string) error {
 			_, _ = color.New(color.FgHiBlack).Fprintf(os.Stdout, "    (none)\n")
 		} else {
 			for _, f := range ws.EnvFile {
-				_, _ = color.New(color.Reset).Fprintf(os.Stdout, "    - %s\n", f)
+				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", f)
 			}
 		}
 
-		_, _ = color.New(color.Reset).Fprintf(os.Stdout, "\n")
+		_, _ = fmt.Fprintf(os.Stdout, "\n")
 	}
 
 	_ = ctx // silence unused variable warning

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -35,21 +36,21 @@ func runConfig(cmd *cobra.Command, args []string) error {
 	if mode == "" {
 		mode = "(auto-detect)"
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "Mode: %s\n", mode)
+	_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "Mode: %s\n", mode)
 
 	baseDockerfile := cfg.Base.Dockerfile
 	if baseDockerfile == "" {
 		baseDockerfile = "(embedded)"
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "Base Dockerfile: %s\n", baseDockerfile)
+	_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "Base Dockerfile: %s\n", baseDockerfile)
 
 	defaultsImage := cfg.Defaults.Image
 	if defaultsImage == "" {
 		defaultsImage = "(not set)"
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "Defaults Image: %s\n", defaultsImage)
+	_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "Defaults Image: %s\n", defaultsImage)
 
-	_, _ = fmt.Fprintf(os.Stdout, "Defaults Allowed Hosts:\n")
+	_, _ = color.New(color.FgCyan, color.Bold).Fprintf(os.Stdout, "Defaults Allowed Hosts:\n")
 	if len(cfg.Defaults.AllowedHosts) == 0 {
 		_, _ = fmt.Fprintf(os.Stdout, "  (none)\n")
 	} else {

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -34,7 +34,7 @@ func runDown(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(composePath); err != nil {
 		if os.IsNotExist(err) {
-			color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
+			_, _ = color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 			return nil
 		}
 		return fmt.Errorf("stat compose file: %w", err)
@@ -44,16 +44,16 @@ func runDown(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	running, err := client.IsRunning(ctx)
 	if err != nil || !running {
-		color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
+		_, _ = color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 		return nil
 	}
 
-	color.New(color.FgCyan).Printf("Stopping workspace %s...\n", ws.Name)
+	_, _ = color.New(color.FgCyan).Printf("Stopping workspace %s...\n", ws.Name)
 	if err := client.Down(ctx); err != nil {
 		return fmt.Errorf("stop workspace: %w", err)
 	}
 
-	color.New(color.FgGreen).Printf("Workspace %s stopped\n", ws.Name)
+	_, _ = color.New(color.FgGreen).Printf("Workspace %s stopped\n", ws.Name)
 	return nil
 }
 

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
@@ -33,7 +34,7 @@ func runDown(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(composePath); err != nil {
 		if os.IsNotExist(err) {
-			fmt.Printf("Workspace %s is not running\n", ws.Name)
+			color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 			return nil
 		}
 		return fmt.Errorf("stat compose file: %w", err)
@@ -43,16 +44,16 @@ func runDown(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	running, err := client.IsRunning(ctx)
 	if err != nil || !running {
-		fmt.Printf("Workspace %s is not running\n", ws.Name)
+		color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 		return nil
 	}
 
-	fmt.Printf("Stopping workspace %s...\n", ws.Name)
+	color.New(color.FgCyan).Printf("Stopping workspace %s...\n", ws.Name)
 	if err := client.Down(ctx); err != nil {
 		return fmt.Errorf("stop workspace: %w", err)
 	}
 
-	fmt.Printf("Workspace %s stopped\n", ws.Name)
+	color.New(color.FgGreen).Printf("Workspace %s stopped\n", ws.Name)
 	return nil
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
@@ -27,6 +28,11 @@ var rootCmd = &cobra.Command{
 	Short:        "Manage sandboxed OpenCode Docker environments",
 	SilenceUsage: true,
 	Args:         cobra.MaximumNArgs(1),
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if noColor, _ := cmd.Flags().GetBool("no-color"); noColor {
+			color.NoColor = true
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -129,6 +135,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&workspaceFlag, "workspace", "w", "default", "workspace name")
 	rootCmd.PersistentFlags().BoolVar(&remoteFlag, "remote", false, "Use remote mode (host-side opencode attach)")
 	rootCmd.PersistentFlags().BoolVar(&execFlag, "exec", false, "Use exec mode (docker exec opencode inside container)")
+	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
 	rootCmd.MarkFlagsMutuallyExclusive("remote", "exec")
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -52,7 +52,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !workspace.MatchesCWD(ws, targetPath) {
-			color.New(color.FgYellow, color.Bold).Printf("Path %s is not in workspace %s. Add it? [y/N]: ", targetPath, ws.Name)
+			_, _ = color.New(color.FgYellow, color.Bold).Printf("Path %s is not in workspace %s. Add it? [y/N]: ", targetPath, ws.Name)
 			answer, err := readLineCtx(ctx)
 			if err != nil {
 				return fmt.Errorf("read add-to-workspace prompt response: %w", err)
@@ -74,7 +74,7 @@ var rootCmd = &cobra.Command{
 			if err := config.AddPath(workspaceFlag, targetPath); err != nil {
 				return fmt.Errorf("add path %q to workspace %q: %w", targetPath, workspaceFlag, err)
 			}
-			color.New(color.FgGreen).Printf("Added %s to workspace %s\n", targetPath, workspaceFlag)
+			_, _ = color.New(color.FgGreen).Printf("Added %s to workspace %s\n", targetPath, workspaceFlag)
 
 			cfg, err = config.Load()
 			if err != nil {
@@ -97,11 +97,11 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !running {
-			color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
+			_, _ = color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
 			if err := runUp(ctx); err != nil {
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}
-			color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
+			_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
 			if err := waitForReady(ctx, ws.Port, client); err != nil {
 				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 			}
@@ -117,10 +117,10 @@ var rootCmd = &cobra.Command{
 		var attachErr error
 		switch mode {
 		case config.ModeExec:
-			color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
+			_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
 			attachErr = attachExec(attachCtx, client)
 		default:
-			color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
+			_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
 			attachErr = attachOnHost(attachCtx, ws)
 		}
 		if attachErr != nil {
@@ -191,8 +191,8 @@ func confirmBroadPath(ctx context.Context, path string) (bool, error) {
 		return true, nil
 	}
 
-	color.New(color.FgYellow).Printf("WARNING: %q is a very broad path — this will mount your entire directory tree into the container.\n", path)
-	color.New(color.FgYellow, color.Bold).Print("Are you sure? [y/N]: ")
+	_, _ = color.New(color.FgYellow).Printf("WARNING: %q is a very broad path — this will mount your entire directory tree into the container.\n", path)
+	_, _ = color.New(color.FgYellow, color.Bold).Print("Are you sure? [y/N]: ")
 
 	answer, err := readLineCtx(ctx)
 	if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -52,7 +52,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !workspace.MatchesCWD(ws, targetPath) {
-			fmt.Printf("Path %s is not in workspace %s. Add it? [y/N]: ", targetPath, ws.Name)
+			color.New(color.FgYellow, color.Bold).Printf("Path %s is not in workspace %s. Add it? [y/N]: ", targetPath, ws.Name)
 			answer, err := readLineCtx(ctx)
 			if err != nil {
 				return fmt.Errorf("read add-to-workspace prompt response: %w", err)
@@ -74,7 +74,7 @@ var rootCmd = &cobra.Command{
 			if err := config.AddPath(workspaceFlag, targetPath); err != nil {
 				return fmt.Errorf("add path %q to workspace %q: %w", targetPath, workspaceFlag, err)
 			}
-			fmt.Printf("Added %s to workspace %s\n", targetPath, workspaceFlag)
+			color.New(color.FgGreen).Printf("Added %s to workspace %s\n", targetPath, workspaceFlag)
 
 			cfg, err = config.Load()
 			if err != nil {
@@ -97,11 +97,11 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !running {
-			fmt.Printf("Starting workspace %s...\n", ws.Name)
+			color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
 			if err := runUp(ctx); err != nil {
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}
-			fmt.Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
+			color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
 			if err := waitForReady(ctx, ws.Port, client); err != nil {
 				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 			}
@@ -117,10 +117,10 @@ var rootCmd = &cobra.Command{
 		var attachErr error
 		switch mode {
 		case config.ModeExec:
-			fmt.Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
+			color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
 			attachErr = attachExec(attachCtx, client)
 		default:
-			fmt.Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
+			color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
 			attachErr = attachOnHost(attachCtx, ws)
 		}
 		if attachErr != nil {
@@ -191,8 +191,8 @@ func confirmBroadPath(ctx context.Context, path string) (bool, error) {
 		return true, nil
 	}
 
-	fmt.Printf("WARNING: %q is a very broad path — this will mount your entire directory tree into the container.\n", path)
-	fmt.Print("Are you sure? [y/N]: ")
+	color.New(color.FgYellow).Printf("WARNING: %q is a very broad path — this will mount your entire directory tree into the container.\n", path)
+	color.New(color.FgYellow, color.Bold).Print("Are you sure? [y/N]: ")
 
 	answer, err := readLineCtx(ctx)
 	if err != nil {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
@@ -33,7 +34,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(composePath); err != nil {
 		if os.IsNotExist(err) {
-			fmt.Printf("Workspace %s is not running\n", ws.Name)
+			color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 			return nil
 		}
 		return fmt.Errorf("stat compose file: %w", err)
@@ -48,12 +49,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if state == "" {
-		fmt.Printf("Workspace %s is not running\n", ws.Name)
+		color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 		return nil
 	}
 
-	fmt.Printf("Workspace: %s\n", ws.Name)
-	fmt.Printf("Port:      %d\n", ws.Port)
+	color.New(color.FgCyan).Printf("Workspace: %s\n", ws.Name)
+	color.New(color.FgCyan).Printf("Port:      %d\n", ws.Port)
 
 	switch state {
 	case "running":
@@ -64,16 +65,21 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 		switch health {
 		case "unhealthy":
-			fmt.Printf("Status:    running (unhealthy)\n")
+			color.New(color.FgCyan).Printf("Status:    ")
+			color.New(color.FgRed).Printf("running (unhealthy)\n")
 		case "starting":
-			fmt.Printf("Status:    running (starting)\n")
+			color.New(color.FgCyan).Printf("Status:    ")
+			color.New(color.FgYellow).Printf("running (starting)\n")
 		default:
-			fmt.Printf("Status:    running\n")
+			color.New(color.FgCyan).Printf("Status:    ")
+			color.New(color.FgGreen).Printf("running\n")
 		}
 	case "exited":
-		fmt.Printf("Status:    exited (code %d)\n", exitCode)
+		color.New(color.FgCyan).Printf("Status:    ")
+		color.New(color.FgRed).Printf("exited (code %d)\n", exitCode)
 	default:
-		fmt.Printf("Status:    %s\n", state)
+		color.New(color.FgCyan).Printf("Status:    ")
+		color.New(color.FgYellow).Printf("%s\n", state)
 	}
 
 	return nil

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -34,7 +34,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	if _, err := os.Stat(composePath); err != nil {
 		if os.IsNotExist(err) {
-			color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
+			_, _ = color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 			return nil
 		}
 		return fmt.Errorf("stat compose file: %w", err)
@@ -49,12 +49,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if state == "" {
-		color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
+		_, _ = color.New(color.FgYellow).Printf("Workspace %s is not running\n", ws.Name)
 		return nil
 	}
 
-	color.New(color.FgCyan).Printf("Workspace: %s\n", ws.Name)
-	color.New(color.FgCyan).Printf("Port:      %d\n", ws.Port)
+	_, _ = color.New(color.FgCyan).Printf("Workspace: %s\n", ws.Name)
+	_, _ = color.New(color.FgCyan).Printf("Port:      %d\n", ws.Port)
 
 	switch state {
 	case "running":
@@ -65,21 +65,21 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 		switch health {
 		case "unhealthy":
-			color.New(color.FgCyan).Printf("Status:    ")
-			color.New(color.FgRed).Printf("running (unhealthy)\n")
+			_, _ = color.New(color.FgCyan).Printf("Status:    ")
+			_, _ = color.New(color.FgRed).Printf("running (unhealthy)\n")
 		case "starting":
-			color.New(color.FgCyan).Printf("Status:    ")
-			color.New(color.FgYellow).Printf("running (starting)\n")
+			_, _ = color.New(color.FgCyan).Printf("Status:    ")
+			_, _ = color.New(color.FgYellow).Printf("running (starting)\n")
 		default:
-			color.New(color.FgCyan).Printf("Status:    ")
-			color.New(color.FgGreen).Printf("running\n")
+			_, _ = color.New(color.FgCyan).Printf("Status:    ")
+			_, _ = color.New(color.FgGreen).Printf("running\n")
 		}
 	case "exited":
-		color.New(color.FgCyan).Printf("Status:    ")
-		color.New(color.FgRed).Printf("exited (code %d)\n", exitCode)
+		_, _ = color.New(color.FgCyan).Printf("Status:    ")
+		_, _ = color.New(color.FgRed).Printf("exited (code %d)\n", exitCode)
 	default:
-		color.New(color.FgCyan).Printf("Status:    ")
-		color.New(color.FgYellow).Printf("%s\n", state)
+		_, _ = color.New(color.FgCyan).Printf("Status:    ")
+		_, _ = color.New(color.FgYellow).Printf("%s\n", state)
 	}
 
 	return nil

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/compose"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
@@ -35,7 +36,7 @@ func runUp(ctx context.Context) error {
 		return fmt.Errorf("resolve workspace %q: %w", workspaceFlag, err)
 	}
 
-	fmt.Printf("Checking Docker availability...\n")
+	color.New(color.FgCyan).Printf("Checking Docker availability...\n")
 	if err := preflightDocker(ctx, ws.Name); err != nil {
 		return fmt.Errorf("docker is not running or not accessible: %w", err)
 	}
@@ -50,11 +51,11 @@ func runUp(ctx context.Context) error {
 		running = false
 	}
 	if running {
-		fmt.Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
+		color.New(color.FgYellow).Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
 		return nil
 	}
 
-	fmt.Printf("Resolving image for workspace %s...\n", ws.Name)
+	color.New(color.FgCyan).Printf("Resolving image for workspace %s...\n", ws.Name)
 	finalImage, err := ResolveAndLayerImage(ctx, cfg, ws, appVersion)
 	if err != nil {
 		return fmt.Errorf("resolve image for workspace %q: %w", ws.Name, err)
@@ -80,18 +81,18 @@ func runUp(ctx context.Context) error {
 		Env:              ws.Env,
 	}
 
-	fmt.Printf("Generating compose configuration...\n")
+	color.New(color.FgCyan).Printf("Generating compose configuration...\n")
 	if err := compose.WriteComposeFile(params, composePath); err != nil {
 		return fmt.Errorf("write compose file for workspace %q: %w", ws.Name, err)
 	}
 
-	fmt.Printf("Starting workspace %s...\n", ws.Name)
+	color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
 	startClient := docker.NewClient(composePath, "", ws.Name)
 	if err := startClient.Up(ctx); err != nil {
 		return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 	}
 
-	fmt.Printf("Workspace %s started on port %d\n", ws.Name, ws.Port)
+	color.New(color.FgGreen).Printf("Workspace %s started on port %d\n", ws.Name, ws.Port)
 	return nil
 }
 
@@ -156,20 +157,20 @@ func ResolveAndLayerImage(ctx context.Context, cfg *config.Config, ws *workspace
 	strategy, strategyImage := resolveImageStrategy(ws.Image, cfg.Defaults.Image, ws.Dockerfile)
 	switch strategy {
 	case strategyDirectImage:
-		fmt.Printf("Using workspace image %s\n", strategyImage)
+		color.New(color.FgCyan).Printf("Using workspace image %s\n", strategyImage)
 		return strategyImage, nil
 	case strategyDefaultsDirect:
-		fmt.Printf("Using default image %s\n", strategyImage)
+		color.New(color.FgCyan).Printf("Using default image %s\n", strategyImage)
 		return strategyImage, nil
 	case strategyDefaultsOverlay:
-		fmt.Printf("Building overlay on default image %s...\n", strategyImage)
+		color.New(color.FgCyan).Printf("Building overlay on default image %s...\n", strategyImage)
 		final, err := docker.BuildOverlayImage(ctx, strategyImage, *ws)
 		if err != nil {
 			return "", fmt.Errorf("build workspace overlay image: %w", err)
 		}
 		return final, nil
 	default: // strategyCascade
-		fmt.Printf("Resolving base image...\n")
+		color.New(color.FgCyan).Printf("Resolving base image...\n")
 		base, err := docker.ResolveBaseImage(ctx, cfg, version)
 		if err != nil {
 			return "", fmt.Errorf("resolve base image: %w", err)

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -36,7 +36,7 @@ func runUp(ctx context.Context) error {
 		return fmt.Errorf("resolve workspace %q: %w", workspaceFlag, err)
 	}
 
-	color.New(color.FgCyan).Printf("Checking Docker availability...\n")
+	_, _ = color.New(color.FgCyan).Printf("Checking Docker availability...\n")
 	if err := preflightDocker(ctx, ws.Name); err != nil {
 		return fmt.Errorf("docker is not running or not accessible: %w", err)
 	}
@@ -51,11 +51,11 @@ func runUp(ctx context.Context) error {
 		running = false
 	}
 	if running {
-		color.New(color.FgYellow).Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
+		_, _ = color.New(color.FgYellow).Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
 		return nil
 	}
 
-	color.New(color.FgCyan).Printf("Resolving image for workspace %s...\n", ws.Name)
+	_, _ = color.New(color.FgCyan).Printf("Resolving image for workspace %s...\n", ws.Name)
 	finalImage, err := ResolveAndLayerImage(ctx, cfg, ws, appVersion)
 	if err != nil {
 		return fmt.Errorf("resolve image for workspace %q: %w", ws.Name, err)
@@ -81,18 +81,18 @@ func runUp(ctx context.Context) error {
 		Env:              ws.Env,
 	}
 
-	color.New(color.FgCyan).Printf("Generating compose configuration...\n")
+	_, _ = color.New(color.FgCyan).Printf("Generating compose configuration...\n")
 	if err := compose.WriteComposeFile(params, composePath); err != nil {
 		return fmt.Errorf("write compose file for workspace %q: %w", ws.Name, err)
 	}
 
-	color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
+	_, _ = color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
 	startClient := docker.NewClient(composePath, "", ws.Name)
 	if err := startClient.Up(ctx); err != nil {
 		return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 	}
 
-	color.New(color.FgGreen).Printf("Workspace %s started on port %d\n", ws.Name, ws.Port)
+	_, _ = color.New(color.FgGreen).Printf("Workspace %s started on port %d\n", ws.Name, ws.Port)
 	return nil
 }
 
@@ -157,20 +157,20 @@ func ResolveAndLayerImage(ctx context.Context, cfg *config.Config, ws *workspace
 	strategy, strategyImage := resolveImageStrategy(ws.Image, cfg.Defaults.Image, ws.Dockerfile)
 	switch strategy {
 	case strategyDirectImage:
-		color.New(color.FgCyan).Printf("Using workspace image %s\n", strategyImage)
+		_, _ = color.New(color.FgCyan).Printf("Using workspace image %s\n", strategyImage)
 		return strategyImage, nil
 	case strategyDefaultsDirect:
-		color.New(color.FgCyan).Printf("Using default image %s\n", strategyImage)
+		_, _ = color.New(color.FgCyan).Printf("Using default image %s\n", strategyImage)
 		return strategyImage, nil
 	case strategyDefaultsOverlay:
-		color.New(color.FgCyan).Printf("Building overlay on default image %s...\n", strategyImage)
+		_, _ = color.New(color.FgCyan).Printf("Building overlay on default image %s...\n", strategyImage)
 		final, err := docker.BuildOverlayImage(ctx, strategyImage, *ws)
 		if err != nil {
 			return "", fmt.Errorf("build workspace overlay image: %w", err)
 		}
 		return final, nil
 	default: // strategyCascade
-		color.New(color.FgCyan).Printf("Resolving base image...\n")
+		_, _ = color.New(color.FgCyan).Printf("Resolving base image...\n")
 		base, err := docker.ResolveBaseImage(ctx, cfg, version)
 		if err != nil {
 			return "", fmt.Errorf("resolve base image: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/fatih/color"
 )
 
 const (
@@ -326,7 +327,7 @@ func Validate(cfg *Config) error {
 			}
 
 			if owner, ok := pathOwners[p]; ok && owner != name {
-				fmt.Fprintf(os.Stderr, "warning: path %q is configured in multiple workspaces: %q and %q\n", p, owner, name)
+				_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, "warning: path %q is configured in multiple workspaces: %q and %q\n", p, owner, name)
 			} else {
 				pathOwners[p] = name
 			}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/build"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/fatih/color"
 	archive "github.com/moby/go-archive"
 	"github.com/moby/term"
 
@@ -42,9 +43,9 @@ func (p *progressEventProcessor) On(events ...api.Resource) {
 	for _, e := range events {
 		switch e.Status {
 		case api.Done:
-			fmt.Printf("  %s %s\n", e.ID, e.Text)
+			color.New(color.FgGreen).Printf("  %s %s\n", e.ID, e.Text)
 		case api.Error:
-			fmt.Printf("  %s %s: %s\n", e.ID, e.Text, e.Details)
+			color.New(color.FgRed).Printf("  %s %s: %s\n", e.ID, e.Text, e.Details)
 		}
 	}
 }
@@ -71,7 +72,7 @@ func (c *Client) Up(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Printf("Loading compose project...\n")
+	color.New(color.FgCyan).Printf("Loading compose project...\n")
 	project, err := c.svc.LoadProject(ctx, api.ProjectLoadOptions{
 		ConfigPaths: []string{c.composeFile},
 		ProjectName: "jailoc-" + c.workspace,
@@ -317,7 +318,7 @@ func (c *Client) initComposeSvc() error {
 func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (string, error) {
 	if cfg != nil && strings.TrimSpace(cfg.Base.Dockerfile) != "" {
 		source := strings.TrimSpace(cfg.Base.Dockerfile)
-		fmt.Printf("Loading preset Dockerfile from %s...\n", source)
+		color.New(color.FgCyan).Printf("Loading preset Dockerfile from %s...\n", source)
 		content, err := loadDockerfile(ctx, source)
 		if err != nil {
 			return "", fmt.Errorf("load dockerfile from %q: %w", source, err)
@@ -329,7 +330,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 		}
 		defer func() { _ = engineCli.Close() }()
 
-		fmt.Printf("Building preset base image...\n")
+		color.New(color.FgCyan).Printf("Building preset base image...\n")
 		tag, err := buildPresetImage(ctx, engineCli, content)
 		if err != nil {
 			return "", fmt.Errorf("build preset image: %w", err)
@@ -345,7 +346,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 	}
 	defer func() { _ = engineCli.Close() }()
 
-	fmt.Printf("Building embedded base image...\n")
+	color.New(color.FgCyan).Printf("Building embedded base image...\n")
 	if err := buildEmbeddedImage(ctx, engineCli, embeddedTag); err != nil {
 		return "", fmt.Errorf("build embedded base image: %w", err)
 	}
@@ -447,7 +448,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 		return base, nil
 	}
 
-	fmt.Printf("Loading workspace Dockerfile from %s...\n", ws.Dockerfile)
+	color.New(color.FgCyan).Printf("Loading workspace Dockerfile from %s...\n", ws.Dockerfile)
 	dockerfileContent, err := loadDockerfile(ctx, ws.Dockerfile)
 	if err != nil {
 		return "", fmt.Errorf("load workspace dockerfile from %q: %w", ws.Dockerfile, err)
@@ -491,7 +492,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 	defer func() { _ = buildCtx.Close() }()
 
 	baseArg := base
-	fmt.Printf("Building workspace overlay image...\n")
+	color.New(color.FgCyan).Printf("Building workspace overlay image...\n")
 	resp, err := engineCli.ImageBuild(ctx, buildCtx, build.ImageBuildOptions{
 		Tags:       []string{overlayTag},
 		BuildArgs:  map[string]*string{"BASE": &baseArg},

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -36,6 +36,11 @@ func displayStream(r io.Reader) error {
 // It prints completion (Done) and error events, skipping intermediate progress ticks.
 type progressEventProcessor struct{}
 
+var (
+	progressDoneColor  = color.New(color.FgGreen)
+	progressErrorColor = color.New(color.FgRed)
+)
+
 func (p *progressEventProcessor) Start(_ context.Context, _ string) {}
 func (p *progressEventProcessor) Done(_ string, _ bool)             {}
 
@@ -43,9 +48,9 @@ func (p *progressEventProcessor) On(events ...api.Resource) {
 	for _, e := range events {
 		switch e.Status {
 		case api.Done:
-			_, _ = color.New(color.FgGreen).Printf("  %s %s\n", e.ID, e.Text)
+			_, _ = progressDoneColor.Printf("  %s %s\n", e.ID, e.Text)
 		case api.Error:
-			_, _ = color.New(color.FgRed).Printf("  %s %s: %s\n", e.ID, e.Text, e.Details)
+			_, _ = progressErrorColor.Printf("  %s %s: %s\n", e.ID, e.Text, e.Details)
 		}
 	}
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -43,9 +43,9 @@ func (p *progressEventProcessor) On(events ...api.Resource) {
 	for _, e := range events {
 		switch e.Status {
 		case api.Done:
-			color.New(color.FgGreen).Printf("  %s %s\n", e.ID, e.Text)
+			_, _ = color.New(color.FgGreen).Printf("  %s %s\n", e.ID, e.Text)
 		case api.Error:
-			color.New(color.FgRed).Printf("  %s %s: %s\n", e.ID, e.Text, e.Details)
+			_, _ = color.New(color.FgRed).Printf("  %s %s: %s\n", e.ID, e.Text, e.Details)
 		}
 	}
 }
@@ -72,7 +72,7 @@ func (c *Client) Up(ctx context.Context) error {
 		return err
 	}
 
-	color.New(color.FgCyan).Printf("Loading compose project...\n")
+	_, _ = color.New(color.FgCyan).Printf("Loading compose project...\n")
 	project, err := c.svc.LoadProject(ctx, api.ProjectLoadOptions{
 		ConfigPaths: []string{c.composeFile},
 		ProjectName: "jailoc-" + c.workspace,
@@ -318,7 +318,7 @@ func (c *Client) initComposeSvc() error {
 func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (string, error) {
 	if cfg != nil && strings.TrimSpace(cfg.Base.Dockerfile) != "" {
 		source := strings.TrimSpace(cfg.Base.Dockerfile)
-		color.New(color.FgCyan).Printf("Loading preset Dockerfile from %s...\n", source)
+		_, _ = color.New(color.FgCyan).Printf("Loading preset Dockerfile from %s...\n", source)
 		content, err := loadDockerfile(ctx, source)
 		if err != nil {
 			return "", fmt.Errorf("load dockerfile from %q: %w", source, err)
@@ -330,7 +330,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 		}
 		defer func() { _ = engineCli.Close() }()
 
-		color.New(color.FgCyan).Printf("Building preset base image...\n")
+		_, _ = color.New(color.FgCyan).Printf("Building preset base image...\n")
 		tag, err := buildPresetImage(ctx, engineCli, content)
 		if err != nil {
 			return "", fmt.Errorf("build preset image: %w", err)
@@ -346,7 +346,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 	}
 	defer func() { _ = engineCli.Close() }()
 
-	color.New(color.FgCyan).Printf("Building embedded base image...\n")
+	_, _ = color.New(color.FgCyan).Printf("Building embedded base image...\n")
 	if err := buildEmbeddedImage(ctx, engineCli, embeddedTag); err != nil {
 		return "", fmt.Errorf("build embedded base image: %w", err)
 	}
@@ -448,7 +448,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 		return base, nil
 	}
 
-	color.New(color.FgCyan).Printf("Loading workspace Dockerfile from %s...\n", ws.Dockerfile)
+	_, _ = color.New(color.FgCyan).Printf("Loading workspace Dockerfile from %s...\n", ws.Dockerfile)
 	dockerfileContent, err := loadDockerfile(ctx, ws.Dockerfile)
 	if err != nil {
 		return "", fmt.Errorf("load workspace dockerfile from %q: %w", ws.Dockerfile, err)
@@ -492,7 +492,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 	defer func() { _ = buildCtx.Close() }()
 
 	baseArg := base
-	color.New(color.FgCyan).Printf("Building workspace overlay image...\n")
+	_, _ = color.New(color.FgCyan).Printf("Building workspace overlay image...\n")
 	resp, err := engineCli.ImageBuild(ctx, buildCtx, build.ImageBuildOptions{
 		Tags:       []string{overlayTag},
 		BuildArgs:  map[string]*string{"BASE": &baseArg},


### PR DESCRIPTION
## Summary

- Add `fatih/color` for semantic terminal coloring across all ~46 user-facing print calls (green=success, cyan=progress, yellow=warning, red=error)
- Add `--no-color` persistent flag; also respects `NO_COLOR` env var and auto-disables for piped/non-TTY output
- No wrapper package, no message text changes, no new test files — purely cosmetic coloring of existing output