### PR TITLE
ci: run integration tests on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,17 @@ jobs:
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: v2.10.1
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    env:
+      OPENCODE_SERVER_PASSWORD: integration-test-password
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.26.x"
+      - name: Run integration tests
+        if: startsWith(github.head_ref || '', 'release-please--branches--')
+        run: go test -tags=integration -v -timeout 10m ./internal/...

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -459,7 +459,6 @@ func TestHealthEndpointAccessible(t *testing.T) {
 
 [workspaces.default]
 paths = [%q]
-env = ["OPENCODE_SERVER_PASSWORD=integration-test-password"]
 `, workspaceDir)
 	if err := os.WriteFile(filepath.Join(home, ".config", "jailoc", "config.toml"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -481,25 +481,31 @@ env = ["OPENCODE_SERVER_PASSWORD=integration-test-password"]
 	var lastErr error
 	deadline := time.Now().Add(90 * time.Second)
 	for time.Now().Before(deadline) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			t.Fatalf("create request: %v", err)
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if reqErr != nil {
+			t.Fatalf("create request: %v", reqErr)
 		}
 		req.SetBasicAuth("opencode", "integration-test-password")
-		resp, err := client.Do(req)
-		if err != nil {
-			lastErr = err
-			t.Logf("health check error (retrying): %v", err)
+		resp, doErr := client.Do(req)
+		if doErr != nil {
+			lastErr = doErr
+			t.Logf("health check error (retrying): %v", doErr)
 			time.Sleep(5 * time.Second)
 			continue
 		}
 		_ = resp.Body.Close()
 		lastStatus = resp.StatusCode
 		if resp.StatusCode == http.StatusOK {
+			if dOut, dErr := runJailoc(ctx, home, "down"); dErr != nil {
+				t.Fatalf("jailoc down: %v\noutput:\n%s", dErr, dOut)
+			}
 			return
 		}
 		t.Logf("health check status %d (retrying)", resp.StatusCode)
 		time.Sleep(5 * time.Second)
+	}
+	if dOut, dErr := runJailoc(ctx, home, "down"); dErr != nil {
+		t.Fatalf("jailoc down: %v\noutput:\n%s", dErr, dOut)
 	}
 	t.Fatalf("health endpoint not accessible after 90s: last status %d, last error: %v", lastStatus, lastErr)
 }

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -5,6 +5,7 @@ package integration_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -441,4 +442,64 @@ func isImagePullOrAuthFailure(output string) bool {
 		strings.Contains(lower, "unauthorized") ||
 		strings.Contains(lower, "denied") ||
 		strings.Contains(lower, "resolve base image")
+}
+
+func TestHealthEndpointAccessible(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	if !dockerAvailable(ctx) {
+		t.Skip("requires Docker daemon")
+	}
+
+	home := testHome(t)
+	workspaceDir := t.TempDir()
+
+	content := fmt.Sprintf(`[base]
+
+[workspaces.default]
+paths = [%q]
+env = ["OPENCODE_SERVER_PASSWORD=integration-test-password"]
+`, workspaceDir)
+	if err := os.WriteFile(filepath.Join(home, ".config", "jailoc", "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Setenv("OPENCODE_SERVER_PASSWORD", "integration-test-password")
+
+	upOut, err := runJailoc(ctx, home, "up")
+	if err != nil {
+		if isImagePullOrAuthFailure(upOut) {
+			t.Skip("requires accessible image registry")
+		}
+		t.Fatalf("jailoc up: %v\noutput: %s", err, upOut)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	url := "http://localhost:4096/global/health"
+	var lastStatus int
+	var lastErr error
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatalf("create request: %v", err)
+		}
+		req.SetBasicAuth("opencode", "integration-test-password")
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			t.Logf("health check error (retrying): %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		_ = resp.Body.Close()
+		lastStatus = resp.StatusCode
+		if resp.StatusCode == http.StatusOK {
+			return
+		}
+		t.Logf("health check status %d (retrying)", resp.StatusCode)
+		time.Sleep(5 * time.Second)
+	}
+	t.Fatalf("health endpoint not accessible after 90s: last status %d, last error: %v", lastStatus, lastErr)
 }


### PR DESCRIPTION
## Summary

- Add `TestHealthEndpointAccessible` integration test that verifies the health endpoint is reachable from the host via HTTP with basic auth after `jailoc up`
- Add `integration-test` CI job that runs integration tests on release-please PRs (branch pattern `release-please--branches--*`)
- Job always runs (required-check compatible) but conditionally executes Docker-dependent steps only on release PRs