### PR TITLE
chore(deps): bump container tool versions and pin unpinned npm packages

### DIFF
--- a/internal/docker/docker_integration_test.go
+++ b/internal/docker/docker_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/moby/moby/api/types/image"
 	dockerclient "github.com/moby/moby/client"
 
 	"github.com/seznam/jailoc/internal/config"
@@ -90,6 +91,37 @@ func TestBuildOverlayImageDefaultBuildContext(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "write temporary workspace Dockerfile") {
 		t.Fatalf("unexpected Dockerfile temp write error: %v", err)
+	}
+}
+
+func TestBuildEmbeddedImage(t *testing.T) {
+	t.Parallel()
+	skipWithoutDocker(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	cli, err := dockerclient.New(dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Fatalf("create Docker client: %v", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	const tag = "jailoc-base:integration-test"
+	if err := buildEmbeddedImage(ctx, cli, tag); err != nil {
+		t.Fatalf("buildEmbeddedImage: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = cli.ImageRemove(context.Background(), tag, image.RemoveOptions{Force: true})
+	})
+
+	inspect, _, err := cli.ImageInspectWithRaw(ctx, tag)
+	if err != nil {
+		t.Fatalf("inspect built image %q: %v", tag, err)
+	}
+	if inspect.ID == "" {
+		t.Fatal("built image has empty ID")
 	}
 }
 

--- a/internal/embed/assets/Dockerfile
+++ b/internal/embed/assets/Dockerfile
@@ -16,11 +16,19 @@
 # Pinned versions — Renovate comments tell the bot which datasource to poll
 # for automated version-bump PRs.
 # renovate: datasource=node-version depName=node versioning=node
-ARG NODE_VERSION=24.14.0
+ARG NODE_VERSION=24.14.1
 # renovate: datasource=npm depName=yaml-language-server
 ARG YAML_LS_VERSION=1.21.0
+# renovate: datasource=npm depName=typescript-language-server
+ARG TS_LS_VERSION=5.1.3
+# renovate: datasource=npm depName=typescript
+ARG TS_VERSION=6.0.2
+# renovate: datasource=npm depName=pyright
+ARG PYRIGHT_VERSION=1.1.408
+# renovate: datasource=npm depName=bash-language-server
+ARG BASH_LS_VERSION=5.6.0
 # renovate: datasource=github-releases depName=sst/opencode
-ARG OPENCODE_VERSION=v1.2.27
+ARG OPENCODE_VERSION=v1.3.17
 
 # =============================================================================
 # Builder stage — compile language servers and install npm modules.
@@ -46,12 +54,16 @@ RUN ARCH=$(dpkg --print-architecture | sed 's/amd64/x64/') \
 # Language servers (npm) — OpenCode uses these for code intelligence
 # (go-to-definition, diagnostics, completions) across languages.
 ARG YAML_LS_VERSION
+ARG TS_LS_VERSION
+ARG TS_VERSION
+ARG PYRIGHT_VERSION
+ARG BASH_LS_VERSION
 RUN npm install -g \
     yaml-language-server@${YAML_LS_VERSION} \
-    typescript-language-server \
-    typescript \
-    pyright \
-    bash-language-server
+    typescript-language-server@${TS_LS_VERSION} \
+    typescript@${TS_VERSION} \
+    pyright@${PYRIGHT_VERSION} \
+    bash-language-server@${BASH_LS_VERSION}
 
 # =============================================================================
 # Final stage — minimal runtime image with only what the agent needs.


### PR DESCRIPTION
## Summary

- Upgrade OpenCode v1.2.27 → v1.3.17, Node.js 24.14.0 → 24.14.1
- Pin previously unpinned npm packages (`typescript-language-server@5.1.3`, `typescript@6.0.2`, `pyright@1.1.408`, `bash-language-server@5.6.0`) with Renovate annotations for automated tracking