### PR TITLE
refactor(docker): bind-mount entrypoint.sh at runtime instead of baking into image

### DIFF
--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -53,7 +53,7 @@ Environment variables configured via `env` or `env_file` in the workspace config
 
 ## The entrypoint sequence
 
-The container image's entrypoint script runs as root and performs three distinct phases before handing off to the agent process.
+The entrypoint script is bind-mounted into the container at runtime by jailoc and runs as root. It performs three distinct phases before handing off to the agent process.
 
 **Phase 1: Network rules.** The script installs iptables rules that shape what the agent can reach. It inserts ACCEPT rules for the dind container, the host gateway, and any hosts or networks you've allowed in config. It then appends DROP rules for RFC 1918 address space, link-local addresses, and CGNAT ranges. Public internet traffic is untouched. See [Network Isolation](network-isolation.md) for a full explanation of the security model.
 

--- a/docs/how-to/custom-images.md
+++ b/docs/how-to/custom-images.md
@@ -28,7 +28,7 @@ Set `image` in `[defaults]` to use a pre-built image as the starting point for a
 image = "myregistry.example.com/myteam/opencode-base:v1.2.3"
 ```
 
-The image must contain OpenCode and the required agent tooling (entrypoint, iptables, setpriv). A plain OS image like `ubuntu:22.04` cannot be used here — the container would fail to start. When `defaults.image` is not set, jailoc builds from its embedded Dockerfile automatically.
+The image must contain OpenCode and the required agent tooling (iptables, setpriv). A plain OS image like `ubuntu:22.04` cannot be used here — the container would fail to start. When `defaults.image` is not set, jailoc builds from its embedded Dockerfile automatically.
 
 With this set, a workspace that adds its own `dockerfile` builds on top of the specified image:
 
@@ -42,38 +42,26 @@ A workspace without a `dockerfile` receives the specified image as-is.
 
 ---
 
-## Use a local Dockerfile as the base image
+## Use a custom Dockerfile as the base image
 
-Set `dockerfile` in the global `[base]` section to an absolute path on your host. jailoc reads the file, builds it locally, and tags the result with a content-based hash (`jailoc-base:preset-<hash>`).
+Set `dockerfile` in the global `[base]` section to a local path or HTTP(S) URL. jailoc reads (or downloads) the file, builds it locally, and tags the result with a content-based hash (`jailoc-base:preset-<hash>`).
 
 ```toml
 [base]
 dockerfile = "/opt/myorg/base.Dockerfile"
 ```
 
-Tilde paths work too:
+Tilde paths and HTTP(S) URLs work too:
 
 ```toml
 [base]
 dockerfile = "~/dockerfiles/base.Dockerfile"
-```
-
-!!! warning
-    If the file doesn't exist or the build fails, jailoc aborts. There is no fallback to the embedded image.
-
----
-
-## Use a remote Dockerfile URL as the base image
-
-Set `dockerfile` in `[base]` to an HTTP(S) URL. jailoc downloads the file, builds it locally, and tags the result with a content-based hash.
-
-```toml
-[base]
+# or
 dockerfile = "https://git.example.com/team/dockerfiles/-/raw/main/opencode.Dockerfile"
 ```
 
 !!! warning
-    If the download fails or exceeds 1 MiB, jailoc aborts. The URL must be reachable at `jailoc up` time.
+    If the file doesn't exist, the download fails (or exceeds 1 MiB), or the build fails, jailoc aborts. There is no fallback to the embedded image.
 
 ---
 
@@ -179,12 +167,33 @@ COPY --from=builder /bin/mytool /usr/local/bin/mytool
 
 This keeps the final image free of compilers and intermediate artifacts.
 
+### Install a custom binary
+
+To add a pre-built binary from a release URL, download and install it in a single `RUN` layer:
+
+```dockerfile
+ARG BASE
+FROM ${BASE}
+
+RUN curl -fsSL https://github.com/org/tool/releases/download/v1.0/tool-linux-amd64 \
+    -o /usr/local/bin/tool \
+    && chmod +x /usr/local/bin/tool
+```
+
+For archives that need extraction:
+
+```dockerfile
+RUN curl -fsSL https://github.com/org/tool/releases/download/v1.0/tool-linux-amd64.tar.gz \
+    | tar -xzf - -C /usr/local/bin tool
+```
+
+If the tool requires compilation, use a [multi-stage build](#use-multi-stage-builds-for-compiled-tools) instead to keep the final image small.
+
 ### What to avoid
 
 !!! danger "Fatal: breaks the container entirely"
     These changes cause the container to fail at startup or make the agent unusable:
 
-    - **Deleting `/usr/local/bin/entrypoint.sh`** — the compose template sets this as the container entrypoint; removing it prevents the container from starting.
     - **Deleting `/home/agent` or removing UID 1000** — the entrypoint drops privileges to UID 1000 and all agent tools run as this user; without it, startup fails.
     - **Removing `iptables`** — the entrypoint uses iptables to enforce network isolation rules; without it, the container exits immediately.
     - **Removing `setpriv`** — the entrypoint calls `setpriv` to drop capabilities and switch to UID 1000; without it, the agent runs as root or the container fails to start.

--- a/docs/reference/overlay-compatibility.md
+++ b/docs/reference/overlay-compatibility.md
@@ -12,7 +12,7 @@ When an overlay Dockerfile uses `FROM <parent>`, the following instructions are 
 | `EXPOSE` | Yes | All exposed ports from the parent remain declared |
 | `VOLUME` | Yes | Parent-declared volumes persist; see incompatible changes below |
 | `LABEL` | Yes | Parent labels are merged; overlay labels take precedence on collision |
-| `ENTRYPOINT` | Overridden | Compose template forces `/usr/local/bin/entrypoint.sh` at runtime |
+| `ENTRYPOINT` | Overridden | Compose template sets the entrypoint to a bind-mounted script at runtime |
 | `CMD` | Overridden | Compose template forces `opencode serve ...` at runtime |
 | `USER` | Overridden | Entrypoint drops to UID 1000 via `setpriv`; `USER` instruction has no effect |
 | `WORKDIR` | Overridden | Compose template sets `working_dir` to the first workspace path at runtime |
@@ -26,7 +26,7 @@ The generated `docker-compose.yml` unconditionally sets the following fields for
 
 | Compose field | Value | Source |
 |---------------|-------|--------|
-| `entrypoint` | `["/usr/local/bin/entrypoint.sh"]` | Compose template |
+| `entrypoint` | `["/usr/local/bin/entrypoint.sh"]` | Compose template; script is bind-mounted from the host |
 | `command` | `["opencode", "serve", ...]` | Compose template |
 | `working_dir` | First workspace path from config | Resolved workspace |
 
@@ -38,7 +38,6 @@ The table below lists overlay actions that affect runtime behaviour. Severity le
 
 | Action | Severity | Effect |
 |--------|----------|--------|
-| Delete `/usr/local/bin/entrypoint.sh` | Fatal | Container fails to start; entrypoint binary is missing |
 | Delete `/home/agent` or UID 1000 user | Fatal | Entrypoint `chown` and `setpriv` calls fail; container exits before agent starts |
 | Remove `iptables` package | Fatal | Network isolation setup fails; entrypoint exits with error |
 | Remove `setpriv` package | Fatal | Privilege drop from root to UID 1000 fails; entrypoint cannot continue |

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -112,6 +112,10 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return fmt.Errorf("write allowed files for workspace %q: %w", ws2.Name, err)
 	}
 
+	if err := writeEntrypoint(filepath.Dir(compPath)); err != nil {
+		return err
+	}
+
 	if err := compose.WriteComposeFile(params, compPath); err != nil {
 		return fmt.Errorf("regenerate compose file: %w", err)
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seznam/jailoc/internal/compose"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
+	"github.com/seznam/jailoc/internal/embed"
 	"github.com/seznam/jailoc/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -68,6 +69,13 @@ func runUp(ctx context.Context) error {
 
 	if err := config.WriteAllowedFiles(ws.Name, cfg); err != nil {
 		return fmt.Errorf("write allowed files for workspace %q: %w", ws.Name, err)
+	}
+
+	// Write entrypoint.sh to cache dir for bind-mount into container.
+	// Uses 0o755 (not the usual 0o600) because Docker bind-mounts preserve
+	// host permissions and the script must be executable inside the container.
+	if err := os.WriteFile(filepath.Join(cacheDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil {
+		return fmt.Errorf("write entrypoint: %w", err)
 	}
 
 	params := compose.ComposeParams{

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -74,7 +74,7 @@ func runUp(ctx context.Context) error {
 	// Write entrypoint.sh to cache dir for bind-mount into container.
 	// Uses 0o755 (not the usual 0o600) because Docker bind-mounts preserve
 	// host permissions and the script must be executable inside the container.
-	if err := os.WriteFile(filepath.Join(cacheDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(cacheDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil { //nolint:gosec // 0o755 required: bind-mount preserves host perms, script must be executable in container
 		return fmt.Errorf("write entrypoint: %w", err)
 	}
 

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -71,11 +71,8 @@ func runUp(ctx context.Context) error {
 		return fmt.Errorf("write allowed files for workspace %q: %w", ws.Name, err)
 	}
 
-	// Write entrypoint.sh to cache dir for bind-mount into container.
-	// Uses 0o755 (not the usual 0o600) because Docker bind-mounts preserve
-	// host permissions and the script must be executable inside the container.
-	if err := os.WriteFile(filepath.Join(cacheDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil { //nolint:gosec // 0o755 required: bind-mount preserves host perms, script must be executable in container
-		return fmt.Errorf("write entrypoint: %w", err)
+	if err := writeEntrypoint(cacheDir); err != nil {
+		return err
 	}
 
 	params := compose.ComposeParams{
@@ -199,6 +196,21 @@ func isComposeFileMissing(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "no such file or directory") ||
 		strings.Contains(msg, "open ") && strings.Contains(msg, "docker-compose.yml")
+}
+
+// writeEntrypoint writes the embedded entrypoint.sh to the workspace cache dir
+// so it can be bind-mounted into the container. Uses 0o755 (not the usual 0o600)
+// because Docker bind-mounts preserve host permissions and the script must be
+// executable inside the container.
+func writeEntrypoint(cacheDir string) error {
+	p := filepath.Join(cacheDir, "entrypoint.sh")
+	if err := os.WriteFile(p, embed.Entrypoint(), 0o755); err != nil { //nolint:gosec // 0o755 required: bind-mount preserves host perms, script must be executable in container
+		return fmt.Errorf("write entrypoint: %w", err)
+	}
+	if err := os.Chmod(p, 0o755); err != nil { //nolint:gosec // ensure +x even when file already existed
+		return fmt.Errorf("chmod entrypoint: %w", err)
+	}
+	return nil
 }
 
 func init() {

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/seznam/jailoc/internal/embed"
 )
 
 func TestIsComposeFileMissing(t *testing.T) {
@@ -199,5 +202,33 @@ func TestResolveImageStrategy(t *testing.T) {
 				t.Fatalf("resolveImageStrategy(%q, %q, %q) image = %q, want %q", tc.wsImage, tc.defaultsImage, tc.wsDockerfile, gotImage, tc.wantImage)
 			}
 		})
+	}
+}
+
+func TestWriteEntrypointToCache(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil {
+		t.Fatalf("os.WriteFile failed: %v", err)
+	}
+
+	entrypointPath := filepath.Join(tmpDir, "entrypoint.sh")
+	info, err := os.Stat(entrypointPath)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) failed: %v", entrypointPath, err)
+	}
+
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("entrypoint.sh permissions %o should have at least one executable bit set", info.Mode()&0o777)
+	}
+
+	data, err := os.ReadFile(entrypointPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) failed: %v", entrypointPath, err)
+	}
+	if !bytes.Equal(data, embed.Entrypoint()) {
+		t.Fatalf("entrypoint.sh content does not match embedded asset")
 	}
 }

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -208,27 +208,53 @@ func TestResolveImageStrategy(t *testing.T) {
 func TestWriteEntrypointToCache(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	t.Run("creates executable file with correct content", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
 
-	if err := os.WriteFile(filepath.Join(tmpDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil { //nolint:gosec // mirrors production: 0o755 required for executable bind-mount
-		t.Fatalf("os.WriteFile failed: %v", err)
-	}
+		if err := writeEntrypoint(tmpDir); err != nil {
+			t.Fatalf("writeEntrypoint failed: %v", err)
+		}
 
-	entrypointPath := filepath.Join(tmpDir, "entrypoint.sh")
-	info, err := os.Stat(entrypointPath)
-	if err != nil {
-		t.Fatalf("os.Stat(%q) failed: %v", entrypointPath, err)
-	}
+		entrypointPath := filepath.Join(tmpDir, "entrypoint.sh")
+		info, err := os.Stat(entrypointPath)
+		if err != nil {
+			t.Fatalf("os.Stat(%q) failed: %v", entrypointPath, err)
+		}
 
-	if info.Mode()&0o111 == 0 {
-		t.Fatalf("entrypoint.sh permissions %o should have at least one executable bit set", info.Mode()&0o777)
-	}
+		if info.Mode()&0o111 == 0 {
+			t.Fatalf("entrypoint.sh permissions %o should have at least one executable bit set", info.Mode()&0o777)
+		}
 
-	data, err := os.ReadFile(entrypointPath) //nolint:gosec // path constructed from t.TempDir(), fully controlled
-	if err != nil {
-		t.Fatalf("os.ReadFile(%q) failed: %v", entrypointPath, err)
-	}
-	if !bytes.Equal(data, embed.Entrypoint()) {
-		t.Fatalf("entrypoint.sh content does not match embedded asset")
-	}
+		data, err := os.ReadFile(entrypointPath) //nolint:gosec // path constructed from t.TempDir(), fully controlled
+		if err != nil {
+			t.Fatalf("os.ReadFile(%q) failed: %v", entrypointPath, err)
+		}
+		if !bytes.Equal(data, embed.Entrypoint()) {
+			t.Fatalf("entrypoint.sh content does not match embedded asset")
+		}
+	})
+
+	t.Run("fixes permissions on existing file", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+
+		entrypointPath := filepath.Join(tmpDir, "entrypoint.sh")
+		if err := os.WriteFile(entrypointPath, []byte("old"), 0o600); err != nil { //nolint:gosec // test setup
+			t.Fatalf("setup WriteFile failed: %v", err)
+		}
+
+		if err := writeEntrypoint(tmpDir); err != nil {
+			t.Fatalf("writeEntrypoint failed: %v", err)
+		}
+
+		info, err := os.Stat(entrypointPath)
+		if err != nil {
+			t.Fatalf("os.Stat(%q) failed: %v", entrypointPath, err)
+		}
+
+		if info.Mode().Perm() != 0o755 {
+			t.Fatalf("expected permissions 0o755, got %o", info.Mode().Perm())
+		}
+	})
 }

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -210,7 +210,7 @@ func TestWriteEntrypointToCache(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	if err := os.WriteFile(filepath.Join(tmpDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "entrypoint.sh"), embed.Entrypoint(), 0o755); err != nil { //nolint:gosec // mirrors production: 0o755 required for executable bind-mount
 		t.Fatalf("os.WriteFile failed: %v", err)
 	}
 
@@ -224,7 +224,7 @@ func TestWriteEntrypointToCache(t *testing.T) {
 		t.Fatalf("entrypoint.sh permissions %o should have at least one executable bit set", info.Mode()&0o777)
 	}
 
-	data, err := os.ReadFile(entrypointPath)
+	data, err := os.ReadFile(entrypointPath) //nolint:gosec // path constructed from t.TempDir(), fully controlled
 	if err != nil {
 		t.Fatalf("os.ReadFile(%q) failed: %v", entrypointPath, err)
 	}

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -37,6 +37,7 @@ func TestGenerateComposeSinglePath(t *testing.T) {
 	assertContains(t, rendered, "healthcheck:")
 	assertContains(t, rendered, "$$OPENCODE_SERVER_PASSWORD")
 	assertContains(t, rendered, "/global/health")
+	assertContains(t, rendered, "entrypoint.sh:/usr/local/bin/entrypoint.sh:ro")
 }
 
 func TestGenerateComposeMultiplePaths(t *testing.T) {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -371,11 +371,6 @@ func buildEmbeddedImage(ctx context.Context, cli dockerclient.APIClient, tag str
 		return fmt.Errorf("write embedded Dockerfile to %q: %w", dockerfilePath, err)
 	}
 
-	entrypointPath := filepath.Join(tmpDir, "entrypoint.sh")
-	if err := os.WriteFile(entrypointPath, embed.Entrypoint(), 0o600); err != nil {
-		return fmt.Errorf("write embedded entrypoint.sh to %q: %w", entrypointPath, err)
-	}
-
 	buildCtx, err := archive.TarWithOptions(tmpDir, &archive.TarOptions{})
 	if err != nil {
 		return fmt.Errorf("create build context tar for %q: %w", tmpDir, err)
@@ -412,11 +407,6 @@ func buildPresetImage(ctx context.Context, cli dockerclient.APIClient, dockerfil
 	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
 	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0o600); err != nil {
 		return "", fmt.Errorf("write preset Dockerfile to %q: %w", dockerfilePath, err)
-	}
-
-	entrypointPath := filepath.Join(tmpDir, "entrypoint.sh")
-	if err := os.WriteFile(entrypointPath, embed.Entrypoint(), 0o600); err != nil {
-		return "", fmt.Errorf("write entrypoint.sh to %q: %w", entrypointPath, err)
 	}
 
 	hash := sha256.Sum256(dockerfileContent)

--- a/internal/embed/assets/Dockerfile
+++ b/internal/embed/assets/Dockerfile
@@ -127,19 +127,10 @@ RUN curl -fsSL https://opencode.ai/install | bash -s -- --version ${OPENCODE_VER
 USER root
 RUN cp /home/agent/.opencode/bin/opencode /usr/local/bin/opencode && chmod +x /usr/local/bin/opencode
 
-# Entrypoint — runs as root on container start to:
-#   1. Configure iptables (allow DinD sidecar + gateway + allowed hosts,
-#      block RFC 1918 / link-local / CGNAT private networks)
-#   2. chown data directories
-#   3. Drop privileges to agent (UID 1000) via setpriv --no-new-privs
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
 # PATH includes agent's local bin dirs for tools installed as the agent user
 # (e.g. uv from preset overlays goes to ~/.local/bin).
 ENV PATH="/home/agent/.local/bin:/home/agent/.opencode/bin:${PATH}"
 
 # Default OpenCode serve port — jailoc assigns ports starting at 4096.
 EXPOSE 4096
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["opencode", "serve", "--hostname", "0.0.0.0", "--port", "4096"]

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -15,6 +15,7 @@ services:
       - ${HOME}/.claude/transcripts:/home/agent/.claude/transcripts
       - ${HOME}/.agents:/home/agent/.agents:ro
       - ${HOME}/.config/jailoc/workspaces/{{.WorkspaceName}}:/etc/jailoc:ro
+      - ${HOME}/.cache/jailoc/{{.WorkspaceName}}/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - opencode-data-{{.WorkspaceName}}:/home/agent/.local/share/opencode
       - opencode-cache-{{.WorkspaceName}}:/home/agent/.cache
       - dind-certs-client:/certs/client:ro


### PR DESCRIPTION
## Summary

- Bind-mount `entrypoint.sh` from host cache dir (`~/.cache/jailoc/{workspace}/`) into the container at runtime instead of `COPY`ing it into the Docker image at build time
- Write embedded `entrypoint.sh` to cache dir on every `jailoc up` (with `0o755` for bind-mount executability)
- Remove `COPY entrypoint.sh`, `RUN chmod +x`, and `ENTRYPOINT` directive from embedded Dockerfile; remove entrypoint writes from `buildEmbeddedImage()` and `buildPresetImage()` build contexts

Entrypoint changes now take effect without image rebuilds.

## Changes

| File | What |
|------|------|
| `docker-compose.yml.tmpl` | New bind-mount volume for `entrypoint.sh:ro` |
| `Dockerfile` | Removed `COPY`/`chmod`/`ENTRYPOINT`; `CMD` preserved |
| `up.go` | Write `entrypoint.sh` to cache dir before compose generation |
| `docker.go` | Removed entrypoint writes from both image build functions |
| `compose_test.go` | Assert new bind-mount in rendered template |
| `up_test.go` | `TestWriteEntrypointToCache` — permissions + content verification |