### PR TITLE
fix(ci): use existing draft release to prevent duplicate releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,6 +36,7 @@ release:
   disable: false
   draft: false
   mode: append
+  use_existing_draft: true
   github:
     owner: seznam
     name: jailoc


### PR DESCRIPTION
## Summary

- Add `use_existing_draft: true` to `.goreleaser.yml` so GoReleaser finds and updates the draft release created by Release Please instead of creating a second release for the same tag
- Fixes the doubled v1.8.0 release — `mode: append` alone doesn't match draft releases because GoReleaser's default `GetReleaseByTag` doesn't reliably find drafts