### PR TITLE
feat: automatic workspace selection by path

### DIFF
--- a/docs/explanation/access-modes.md
+++ b/docs/explanation/access-modes.md
@@ -1,10 +1,10 @@
 # Access Modes
 
-When you run `jailoc attach`, you're connecting to an agent running inside a container. There are two distinct ways that connection can work, and they have meaningfully different characteristics. Understanding the difference helps you choose the right mode and explains some behaviours that might otherwise seem surprising.
+When you run `jailoc`, you're connecting to an agent running inside a container. There are two distinct ways that connection can work, and they have meaningfully different characteristics. Understanding the difference helps you choose the right mode and explains some behaviours that might otherwise seem surprising.
 
 ## Remote mode
 
-In remote mode, `opencode serve` runs inside the container and listens on a TCP port. On the host, `jailoc attach` calls `opencode attach` pointing at that port. The agent process and the terminal UI are in different places, connected by a network socket.
+In remote mode, `opencode serve` runs inside the container and listens on a TCP port. On the host, `jailoc` calls `opencode attach` pointing at that port. The agent process and the terminal UI are in different places, connected by a network socket.
 
 ```mermaid
 flowchart TB
@@ -31,7 +31,7 @@ If the `opencode` container stops or is recreated while you are attached, `jailo
 
 ## Exec mode
 
-In exec mode, `jailoc attach` uses `docker exec` to run `opencode attach` inside the container, connecting to the same `opencode serve` process. Both the client and the server run inside the container, with stdin/stdout piped through docker exec to the host terminal.
+In exec mode, `jailoc` uses `docker exec` to run `opencode attach` inside the container, connecting to the same `opencode serve` process. Both the client and the server run inside the container, with stdin/stdout piped through docker exec to the host terminal.
 
 ```mermaid
 flowchart TB
@@ -52,7 +52,7 @@ The terminal pipeline goes host stdin → docker exec → `opencode attach` (ins
 
 ### Why this matters
 
-Because rendering happens through docker exec's pipe, terminal capabilities are limited. Some keyboard shortcuts don't reach the application correctly, and clipboard behaviour depends on how your terminal emulator handles the piped session. If you close the terminal or disconnect, the exec'd `opencode attach` client exits, but the server and its agent session keep running. You can reconnect by running `jailoc attach --exec` again.
+Because rendering happens through docker exec's pipe, terminal capabilities are limited. Some keyboard shortcuts don't reach the application correctly, and clipboard behaviour depends on how your terminal emulator handles the piped session. If you close the terminal or disconnect, the exec'd `opencode attach` client exits, but the server and its agent session keep running. You can reconnect by running `jailoc --exec` again.
 
 The upside is that exec mode has no host-side dependencies. As long as Docker is available, it works. You don't need opencode installed on your machine.
 

--- a/docs/how-to/access-modes.md
+++ b/docs/how-to/access-modes.md
@@ -14,7 +14,7 @@ By default, jailoc checks whether `opencode` or `opencode-cli` is on your `PATH`
 You don't need any config for this. Just run:
 
 ```bash
-jailoc attach
+jailoc
 ```
 
 ---
@@ -44,8 +44,8 @@ Valid values:
 Use CLI flags to force a mode without changing your config:
 
 ```bash
-jailoc attach --remote   # force remote mode for this run
-jailoc attach --exec     # force exec mode for this run
+jailoc --remote   # force remote mode for this run
+jailoc --exec     # force exec mode for this run
 ```
 
 The flag takes precedence over both the config value and auto-detection.
@@ -57,10 +57,10 @@ The flag takes precedence over both the config value and auto-detection.
 By default, `opencode attach` opens the workspace root. Use `--dir` to open a subdirectory instead:
 
 ```bash
-jailoc attach --dir /home/you/projects/myproject/src
+jailoc --dir /home/you/projects/myproject/src
 ```
 
-The root `jailoc` command does this automatically — it resolves the current working directory and forwards it as `--dir`:
+The root `jailoc` command does this automatically when run from a subdirectory — it resolves the current working directory and forwards it as `--dir`:
 
 ```bash
 cd ~/projects/myproject/src
@@ -78,4 +78,4 @@ Both modes fail fast if the `opencode` container stops or is replaced while you 
 - In **remote** mode, jailoc terminates the host-side `opencode attach` process instead of leaving it blocked against a dead container.
 - In **exec** mode, jailoc cancels the `docker exec` session so your terminal is restored instead of staying stuck in a hung interactive session.
 
-This is most noticeable when you rebuild, bake, or otherwise replace the workspace container while an attach session is active. After the attach command exits, run `jailoc attach` again to reconnect to the new container.
+This is most noticeable when you rebuild, bake, or otherwise replace the workspace container while an attach session is active. After the attach command exits, run `jailoc` again to reconnect to the new container.

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -14,6 +14,30 @@ The file is created automatically on first run with a `default` workspace alread
 
 ---
 
+## Automatic workspace detection
+
+Most commands accept an explicit `--workspace` flag. When omitted, jailoc selects the workspace automatically using this resolution order:
+
+1. **Explicit `--workspace` flag** — if set, use that workspace.
+2. **Longest-prefix CWD match** — compare the current working directory against every workspace's configured `paths`. The workspace whose path is the longest matching prefix wins. Equal-length matches break alphabetically.
+3. **`default` fallback** — if no path matches, the `default` workspace is used.
+
+Given these two workspaces:
+
+```toml
+[workspaces.broad]
+paths = ["/home/you/projects"]
+
+[workspaces.specific]
+paths = ["/home/you/projects/api"]
+```
+
+Running `jailoc up` from `/home/you/projects/api/src` selects `specific` (longer prefix match). Running from `/home/you/projects/other` selects `broad`.
+
+`jailoc add` uses the path being added (not the raw CWD) for detection. If `--workspace` is set explicitly and the path being added is not under any of that workspace's configured paths, jailoc returns an error.
+
+---
+
 ## Define a workspace
 
 Each workspace is a `[workspaces.<name>]` section. The only required field is `paths`.

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -148,7 +148,7 @@ build_context = "/home/you/projects/myproject/docker"
 
 ## Set a connection mode
 
-Control how `jailoc attach` connects to the running container:
+Control how `jailoc` connects to the running container:
 
 ```toml
 [workspaces.myproject]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,7 +12,7 @@ Key facts:
 
 ## Reference
 
-- [CLI Reference](https://seznam.github.io/jailoc/reference/cli/): All subcommands (`up`, `down`, `attach`, `logs`, `status`, `add`, `config`) with flags and usage
+- [CLI Reference](https://seznam.github.io/jailoc/reference/cli/): All subcommands (`up`, `down`, `logs`, `status`, `add`, `config`) with flags and usage
 - [Configuration Reference](https://seznam.github.io/jailoc/reference/configuration/): Every `config.toml` field — `[base]`, `[defaults]`, `[workspaces.<name>]` — types, defaults, validation rules, merge semantics
 - [Image Resolution](https://seznam.github.io/jailoc/reference/image-resolution/): 5-step resolution cascade with step details, triggers, constraints, and image tag summary
 - [Default Image Contents](https://seznam.github.io/jailoc/reference/default-image/): Tools and runtimes shipped in the embedded base image

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,28 +64,6 @@ When `--workspace` is not set, resolves the workspace whose configured path best
 
 ---
 
-### `jailoc attach`
-
-Attach to a running workspace environment from the host.
-
-```
-jailoc attach [flags]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--remote` | Force remote connection mode (runs `opencode attach` on the host). |
-| `--exec` | Force exec connection mode (runs `docker exec` into the container). |
-| `--dir` | Directory to open in opencode (forwarded as `--dir` to `opencode attach`). |
-
-The workspace must already be running. See [access modes explanation](../explanation/access-modes.md) for the difference between `--remote` and `--exec`.
-
-If the `opencode` container stops or is replaced while attachment is active, `jailoc attach` exits instead of waiting indefinitely for the underlying client session to recover.
-
-When no positional workspace argument and `--workspace` is not set, resolves the workspace from the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
-
----
-
 ### `jailoc status`
 
 Print the state and assigned port for each configured workspace.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,6 +46,8 @@ jailoc up [flags]
 
 Resolves the container image (see [Image Resolution](image-resolution.md)), generates a `docker-compose.yml` in `~/.cache/jailoc/{workspace}/`, and starts two containers: `opencode` and `dind`.
 
+When `--workspace` is not set, resolves the workspace whose configured path best matches the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
+
 ---
 
 ### `jailoc down`
@@ -57,6 +59,8 @@ jailoc down [flags]
 ```
 
 Equivalent to `docker compose down` on the generated compose file. Does not remove named volumes or the image.
+
+When `--workspace` is not set, resolves the workspace whose configured path best matches the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
 
 ---
 
@@ -78,6 +82,8 @@ The workspace must already be running. See [access modes explanation](../explana
 
 If the `opencode` container stops or is replaced while attachment is active, `jailoc attach` exits instead of waiting indefinitely for the underlying client session to recover.
 
+When no positional workspace argument and `--workspace` is not set, resolves the workspace from the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
+
 ---
 
 ### `jailoc status`
@@ -90,6 +96,8 @@ jailoc status [flags]
 
 Output lists all workspaces defined in configuration. For each workspace, shows the container state (running, stopped, or unknown) and the host port it is assigned.
 
+When `--workspace` is not set, resolves the workspace whose configured path best matches the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
+
 ---
 
 ### `jailoc logs`
@@ -101,6 +109,8 @@ jailoc logs [flags]
 ```
 
 Streams combined stdout and stderr from the `opencode` and `dind` containers. Follows log output until interrupted.
+
+When no positional workspace argument and `--workspace` is not set, resolves the workspace from the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
 
 ---
 
@@ -125,3 +135,5 @@ jailoc add [flags]
 ```
 
 Appends the current directory to `workspaces.<name>.paths` in `~/.config/jailoc/config.toml`. The path must not be under a forbidden system prefix. See the [configuration reference](configuration.md) for path validation rules.
+
+When `--workspace` is not set, resolves the workspace from the path being added (longest prefix). If `--workspace` is set explicitly and the path is not under any of that workspace's configured paths, `jailoc add` returns an error. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -72,7 +72,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | `allowed_networks` | string[] | `[]` | CIDR ranges explicitly allowed through the container firewall. |
 | `image` | string | (none) | Pre-built Docker image to use directly for this workspace, bypassing all build steps. Compose pulls the image natively at startup. Cannot be combined with `dockerfile` or `build_context`. |
 | `build_context` | string | (none) | Docker build context directory for the workspace overlay build. When empty and `dockerfile` is a local path, defaults to the parent directory of the Dockerfile. When empty and `dockerfile` is an HTTP URL, a temporary directory is used. Supports `~` expansion. |
-| `mode` | string | `""` | Connection mode for `jailoc attach` and the root `jailoc` command. Accepted values: `"remote"`, `"exec"`, `""` (auto-detect). |
+| `mode` | string | `""` | Connection mode for `jailoc`. Accepted values: `"remote"`, `"exec"`, `""` (auto-detect). |
 | `dockerfile` | string | (none) | Local path (`/...`, `~/...`) or HTTP(S) URL to a Dockerfile for a workspace-specific overlay image. Builds on top of the base image resolved by `[base]` settings. Build failure is fatal. Maximum file size for HTTP sources: 1 MiB. Supports `~` expansion for local paths. |
 | `env` | string[] | `[]` | Environment variables for this workspace. Each entry in `KEY=VALUE` format. These override any global `defaults.env` entry with the same key. Reserved keys are rejected (see Validation Rules). |
 | `env_file` | string[] | `[]` | Paths to `.env` files for this workspace. Each file must exist at config load time. Paths must be absolute (`/...`) or start with `~`. Loaded after global `defaults.env_file` entries. |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -53,9 +53,6 @@ The bare `jailoc` shortcut is convenient, but you can also drive each step expli
 ```bash
 # Start the environment in the background
 jailoc up
-
-# Attach your local opencode TUI to the running agent
-jailoc attach
 ```
 
 This separation is useful when you want to start the workspace and come back to it later, or when you're scripting workspace lifecycle from CI.

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -33,9 +33,21 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	// Auto-detect workspace from target path if not explicitly set
+	if !workspaceExplicit {
+		if resolved, _, err := workspace.ResolveFromCWD(cfg, targetDir); err == nil {
+			workspaceFlag = resolved.Name
+		}
+	}
+
 	ws, err := workspace.Resolve(cfg, workspaceFlag)
 	if err != nil {
 		return fmt.Errorf("resolve workspace %q: %w", workspaceFlag, err)
+	}
+
+	// Conflict detection: explicit -w + path not under workspace → error
+	if workspaceExplicit && !workspace.MatchesCWD(ws, targetDir) {
+		return fmt.Errorf("path %q is not under workspace %q; use a different --workspace or omit the flag for auto-detection", targetDir, workspaceFlag)
 	}
 
 	if isDuplicate(ws.Paths, targetDir) {

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,8 +36,14 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	// Auto-detect workspace from target path if not explicitly set
 	if !workspaceExplicit {
-		if resolved, _, err := workspace.ResolveFromCWD(cfg, targetDir); err == nil {
+		resolved, _, cwdErr := workspace.ResolveFromCWD(cfg, targetDir)
+		switch {
+		case cwdErr == nil:
 			workspaceFlag = resolved.Name
+		case errors.Is(cwdErr, workspace.ErrNoMatch):
+			// no workspace matches target — keep default
+		default:
+			return fmt.Errorf("resolve workspace from target directory: %w", cwdErr)
 		}
 	}
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -46,7 +46,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Conflict detection: explicit -w + path not under workspace → error
-	if workspaceExplicit && !workspace.MatchesCWD(ws, targetDir) {
+	if workspaceExplicit && len(ws.Paths) > 0 && !workspace.MatchesCWD(ws, targetDir) {
 		return fmt.Errorf("path %q is not under workspace %q; use a different --workspace or omit the flag for auto-detection", targetDir, workspaceFlag)
 	}
 

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -57,6 +57,13 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	name := workspaceFlag
 	if len(args) > 0 {
 		name = args[0]
+	} else if !workspaceExplicit {
+		cwd, err := os.Getwd()
+		if err == nil {
+			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+				name = resolved.Name
+			}
+		}
 	}
 
 	ws, err := workspace.Resolve(cfg, name)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -7,27 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
-	"github.com/fatih/color"
-	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
 	"github.com/seznam/jailoc/internal/workspace"
 )
-
-var attachCmd = &cobra.Command{
-	Use:   "attach [workspace]",
-	Short: "Attach to a running workspace (host opencode attach by default)",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runAttach,
-}
-
-var attachDirFlag string
 
 func attachHostArgs(serverURL, password, dir string) []string {
 	args := []string{"attach", serverURL}
@@ -46,68 +34,6 @@ func attachExecArgs(serverURL, dir string) []string {
 		args = append(args, "--dir", dir)
 	}
 	return args
-}
-
-func runAttach(cmd *cobra.Command, args []string) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("load config: %w", err)
-	}
-
-	name := workspaceFlag
-	if len(args) > 0 {
-		name = args[0]
-	} else if !workspaceExplicit {
-		cwd, err := os.Getwd()
-		if err == nil {
-			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
-				name = resolved.Name
-			}
-		}
-	}
-
-	ws, err := workspace.Resolve(cfg, name)
-	if err != nil {
-		return fmt.Errorf("resolve workspace: %w", err)
-	}
-
-	composePath := filepath.Join(ComposeCacheDir(ws.Name), "docker-compose.yml")
-	client := docker.NewClient(composePath, "", ws.Name)
-
-	ctx := cmd.Context()
-	running, err := client.IsRunning(ctx)
-	if err != nil || !running {
-		return fmt.Errorf("workspace %q is not running; run 'jailoc up' first", ws.Name)
-	}
-
-	attachCtx, stop, err := startAttachWatch(ctx, client, ws.Name)
-	if err != nil {
-		return err
-	}
-	defer stop()
-
-	mode := resolveFromFlags(cmd, cfg)
-	var attachErr error
-	switch mode {
-	case config.ModeExec:
-		_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
-		attachErr = attachExec(attachCtx, client, attachDirFlag)
-	default:
-		_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
-		attachErr = attachOnHost(attachCtx, ws, attachDirFlag)
-	}
-
-	if errors.Is(attachErr, errUnhealthy) {
-		_, _ = color.New(color.FgCyan).Fprintf(os.Stderr, "\n--- last %d log lines ---\n", tailLogLines)
-		logCtx, logCancel := context.WithTimeout(ctx, tailLogTimeout)
-		defer logCancel()
-		if logErr := client.TailLogs(logCtx, tailLogLines, os.Stderr); logErr != nil {
-			_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, "failed to retrieve logs: %v\n", logErr)
-		}
-		_, _ = color.New(color.FgRed).Fprintf(os.Stderr, "--- container reported unhealthy; see logs above ---\n")
-	}
-
-	return attachErr
 }
 
 func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string) error {
@@ -161,8 +87,6 @@ func attachExec(ctx context.Context, client *docker.Client, dir string) error {
 const (
 	attachPollInterval = 500 * time.Millisecond
 	attachWaitDelay    = 2 * time.Second
-	tailLogLines       = 50
-	tailLogTimeout     = 10 * time.Second
 )
 
 var errUnhealthy = errors.New("opencode process unhealthy inside container")
@@ -264,9 +188,4 @@ func runCommandWithContext(ctx context.Context, cmd *exec.Cmd, terminate func() 
 			return <-resultCh
 		}
 	}
-}
-
-func init() {
-	rootCmd.AddCommand(attachCmd)
-	attachCmd.Flags().StringVar(&attachDirFlag, "dir", "", "directory to open in opencode (forwarded as --dir to opencode attach)")
 }

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,8 +31,14 @@ func runDown(cmd *cobra.Command, args []string) error {
 	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
-			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+			resolved, _, cwdErr := workspace.ResolveFromCWD(cfg, cwd)
+			switch {
+			case cwdErr == nil:
 				workspaceFlag = resolved.Name
+			case errors.Is(cwdErr, workspace.ErrNoMatch):
+				// no workspace matches CWD — keep default
+			default:
+				return fmt.Errorf("resolve workspace from current directory: %w", cwdErr)
 			}
 		}
 	}

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -25,7 +25,9 @@ func runDown(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	if !workspaceExplicit {
+	if len(args) > 0 {
+		workspaceFlag = args[0]
+	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
 			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -25,6 +25,15 @@ func runDown(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	if !workspaceExplicit {
+		cwd, err := os.Getwd()
+		if err == nil {
+			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+				workspaceFlag = resolved.Name
+			}
+		}
+	}
+
 	ws, err := workspace.Resolve(cfg, workspaceFlag)
 	if err != nil {
 		return fmt.Errorf("resolve workspace: %w", err)

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,8 +36,14 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
-			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+			resolved, _, cwdErr := workspace.ResolveFromCWD(cfg, cwd)
+			switch {
+			case cwdErr == nil:
 				name = resolved.Name
+			case errors.Is(cwdErr, workspace.ErrNoMatch):
+				// no workspace matches CWD — keep default
+			default:
+				return fmt.Errorf("resolve workspace from current directory: %w", cwdErr)
 			}
 		}
 	}

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -32,6 +32,13 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	name := workspaceFlag
 	if len(args) > 0 {
 		name = args[0]
+	} else if !workspaceExplicit {
+		cwd, err := os.Getwd()
+		if err == nil {
+			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+				name = resolved.Name
+			}
+		}
 	}
 
 	ws, err := workspace.Resolve(cfg, name)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -50,8 +51,14 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !workspaceExplicit {
-			if resolved, _, err := workspace.ResolveFromCWD(cfg, targetPath); err == nil {
+			resolved, _, cwdErr := workspace.ResolveFromCWD(cfg, targetPath)
+			switch {
+			case cwdErr == nil:
 				workspaceFlag = resolved.Name
+			case errors.Is(cwdErr, workspace.ErrNoMatch):
+				// no workspace matches target — keep default
+			default:
+				return fmt.Errorf("resolve workspace from target path: %w", cwdErr)
 			}
 		}
 
@@ -107,6 +114,7 @@ var rootCmd = &cobra.Command{
 
 		if !running {
 			_, _ = color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
+			workspaceExplicit = true
 			if err := runUp(ctx, nil); err != nil {
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -20,6 +20,7 @@ import (
 )
 
 var workspaceFlag string
+var workspaceExplicit bool
 var appVersion string
 var remoteFlag, execFlag bool
 
@@ -28,10 +29,12 @@ var rootCmd = &cobra.Command{
 	Short:        "Manage sandboxed OpenCode Docker environments",
 	SilenceUsage: true,
 	Args:         cobra.MaximumNArgs(1),
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		if noColor, _ := cmd.Flags().GetBool("no-color"); noColor {
 			color.NoColor = true
 		}
+		workspaceExplicit = cmd.Flags().Changed("workspace")
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -44,6 +47,12 @@ var rootCmd = &cobra.Command{
 		cfg, err := config.Load()
 		if err != nil {
 			return fmt.Errorf("load config: %w", err)
+		}
+
+		if !workspaceExplicit {
+			if resolved, _, err := workspace.ResolveFromCWD(cfg, targetPath); err == nil {
+				workspaceFlag = resolved.Name
+			}
 		}
 
 		ws, err := workspace.Resolve(cfg, workspaceFlag)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -107,7 +107,7 @@ var rootCmd = &cobra.Command{
 
 		if !running {
 			_, _ = color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
-			if err := runUp(ctx); err != nil {
+			if err := runUp(ctx, nil); err != nil {
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}
 			_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -25,6 +25,15 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	if !workspaceExplicit {
+		cwd, err := os.Getwd()
+		if err == nil {
+			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+				workspaceFlag = resolved.Name
+			}
+		}
+	}
+
 	ws, err := workspace.Resolve(cfg, workspaceFlag)
 	if err != nil {
 		return fmt.Errorf("resolve workspace: %w", err)

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -25,7 +25,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	if !workspaceExplicit {
+	if len(args) > 0 {
+		workspaceFlag = args[0]
+	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
 			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,8 +31,14 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
-			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+			resolved, _, cwdErr := workspace.ResolveFromCWD(cfg, cwd)
+			switch {
+			case cwdErr == nil:
 				workspaceFlag = resolved.Name
+			case errors.Is(cwdErr, workspace.ErrNoMatch):
+				// no workspace matches CWD — keep default
+			default:
+				return fmt.Errorf("resolve workspace from current directory: %w", cwdErr)
 			}
 		}
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -22,17 +22,19 @@ var upCmd = &cobra.Command{
 	Long:  "Start the Docker Compose environment for a workspace. If already running, no-op.",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runUp(cmd.Context())
+		return runUp(cmd.Context(), args)
 	},
 }
 
-func runUp(ctx context.Context) error {
+func runUp(ctx context.Context, args []string) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	if !workspaceExplicit && workspaceFlag == "default" {
+	if len(args) > 0 {
+		workspaceFlag = args[0]
+	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
 			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -32,7 +32,7 @@ func runUp(ctx context.Context) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	if !workspaceExplicit {
+	if !workspaceExplicit && workspaceFlag == "default" {
 		cwd, err := os.Getwd()
 		if err == nil {
 			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,8 +38,14 @@ func runUp(ctx context.Context, args []string) error {
 	} else if !workspaceExplicit {
 		cwd, err := os.Getwd()
 		if err == nil {
-			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+			resolved, _, cwdErr := workspace.ResolveFromCWD(cfg, cwd)
+			switch {
+			case cwdErr == nil:
 				workspaceFlag = resolved.Name
+			case errors.Is(cwdErr, workspace.ErrNoMatch):
+				// no workspace matches CWD — keep default
+			default:
+				return fmt.Errorf("resolve workspace from current directory: %w", cwdErr)
 			}
 		}
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -32,6 +32,15 @@ func runUp(ctx context.Context) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	if !workspaceExplicit {
+		cwd, err := os.Getwd()
+		if err == nil {
+			if resolved, _, err := workspace.ResolveFromCWD(cfg, cwd); err == nil {
+				workspaceFlag = resolved.Name
+			}
+		}
+	}
+
 	ws, err := workspace.Resolve(cfg, workspaceFlag)
 	if err != nil {
 		return fmt.Errorf("resolve workspace %q: %w", workspaceFlag, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2058,3 +2058,195 @@ image = "alpine:latest"
 		})
 	}
 }
+
+func TestValidateErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, "valid.env")
+	writeFile(t, envFile, "KEY=val\n")
+
+	tests := []struct {
+		name        string
+		cfg         *Config
+		wantSubstrs []string // all substrings must appear in the error message
+	}{
+		{
+			name: "invalid workspace name includes the name",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"My Project": {Paths: []string{"/data"}},
+				},
+			},
+			wantSubstrs: []string{"My Project", "must match"},
+		},
+		{
+			name: "invalid CIDR includes workspace name and value",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/data"}, AllowedNetworks: []string{"not-a-cidr"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "not-a-cidr"},
+		},
+		{
+			name: "forbidden path includes workspace name, path, and prefix",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/usr/local/bin"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "/usr/local/bin", "conflicts with container-internal directory"},
+		},
+		{
+			name: "empty path string includes workspace name",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/data", ""}},
+				},
+			},
+			wantSubstrs: []string{"myws", "empty path"},
+		},
+		{
+			name: "invalid mode includes the value",
+			cfg: &Config{
+				Mode:       "banana",
+				Workspaces: map[string]Workspace{},
+			},
+			wantSubstrs: []string{"banana", "invalid mode"},
+		},
+		{
+			name: "env missing equals includes workspace and entry",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Env: []string{"NO_EQUALS"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "NO_EQUALS", "KEY=VALUE"},
+		},
+		{
+			name: "env empty key includes workspace and entry",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Env: []string{"=value"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "=value", "key must not be empty"},
+		},
+		{
+			name: "env reserved key includes workspace and key name",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Env: []string{"DOCKER_HOST=tcp://localhost:2376"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "DOCKER_HOST", "reserved"},
+		},
+		{
+			name: "env_file relative path includes workspace and path",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {EnvFile: []string{"relative/path.env"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "relative/path.env", "must be absolute"},
+		},
+		{
+			name: "env_file nonexistent includes workspace and path",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {EnvFile: []string{"/nonexistent/file.env"}},
+				},
+			},
+			wantSubstrs: []string{"myws", "/nonexistent/file.env", "does not exist"},
+		},
+		{
+			name: "defaults env missing equals includes context",
+			cfg: &Config{
+				Defaults: Defaults{Env: []string{"NOEQUALS"}},
+			},
+			wantSubstrs: []string{"defaults", "NOEQUALS", "KEY=VALUE"},
+		},
+		{
+			name: "defaults env reserved key includes context and key",
+			cfg: &Config{
+				Defaults: Defaults{Env: []string{"OPENCODE_LOG=debug"}},
+			},
+			wantSubstrs: []string{"defaults", "OPENCODE_LOG", "reserved"},
+		},
+		{
+			name: "defaults env_file relative path includes context",
+			cfg: &Config{
+				Defaults: Defaults{EnvFile: []string{"relative.env"}},
+			},
+			wantSubstrs: []string{"defaults", "relative.env", "must be absolute"},
+		},
+		{
+			name: "image and dockerfile conflict includes workspace",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/data"}, Image: "nginx:latest", Dockerfile: "/Dockerfile"},
+				},
+			},
+			wantSubstrs: []string{"myws", "cannot set both", "image", "dockerfile"},
+		},
+		{
+			name: "image and build_context conflict includes workspace",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/data"}, Image: "nginx:latest", BuildContext: "/build"},
+				},
+			},
+			wantSubstrs: []string{"myws", "cannot set both", "image", "build_context"},
+		},
+		{
+			name: "whitespace-only image includes workspace",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/data"}, Image: "   "},
+				},
+			},
+			wantSubstrs: []string{"myws", "image", "must not be empty or whitespace-only"},
+		},
+		{
+			name: "dockerfile relative path includes workspace",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"myws": {Paths: []string{"/data"}, Dockerfile: "relative/Dockerfile"},
+				},
+			},
+			wantSubstrs: []string{"myws", "must be an absolute path"},
+		},
+		{
+			name: "base dockerfile invalid URL includes field",
+			cfg: &Config{
+				Base:       BaseConfig{Dockerfile: "http:///no-host"},
+				Workspaces: map[string]Workspace{},
+			},
+			wantSubstrs: []string{"base dockerfile", "scheme must be http or https"},
+		},
+		{
+			name:        "nil config",
+			cfg:         nil,
+			wantSubstrs: []string{"nil"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := Validate(tt.cfg)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+
+			msg := err.Error()
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error message %q missing expected substring %q", msg, sub)
+				}
+			}
+		})
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -128,19 +128,29 @@ func dedupEnvByKeyLastWins(entries []string) []string {
 }
 
 func ResolveFromCWD(cfg *config.Config, cwd string) (*Resolved, string, error) {
+	var bestWs *Resolved
+	var bestMatchedPath string
+	var bestPathLen int
+
 	for _, name := range workspaceNames(cfg) {
 		resolved, err := Resolve(cfg, name)
 		if err != nil {
-			return nil, "", err
+			continue
 		}
 		for _, p := range resolved.Paths {
-			if pathMatchesCWD(p, cwd) {
-				return resolved, p, nil
+			if pathMatchesCWD(p, cwd) && len(p) > bestPathLen {
+				bestWs = resolved
+				bestMatchedPath = p
+				bestPathLen = len(p)
 			}
 		}
 	}
 
-	return nil, "", fmt.Errorf("no workspace matches current directory %q", cwd)
+	if bestWs == nil {
+		return nil, "", fmt.Errorf("no workspace matches path %s", cwd)
+	}
+
+	return bestWs, bestMatchedPath, nil
 }
 
 func PortForWorkspace(cfg *config.Config, name string) int {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -128,29 +128,39 @@ func dedupEnvByKeyLastWins(entries []string) []string {
 }
 
 func ResolveFromCWD(cfg *config.Config, cwd string) (*Resolved, string, error) {
-	var bestWs *Resolved
+	var bestName string
 	var bestMatchedPath string
 	var bestSegments int
 
 	for _, name := range workspaceNames(cfg) {
-		resolved, err := Resolve(cfg, name)
-		if err != nil {
-			continue
-		}
-		for _, p := range resolved.Paths {
+		ws := cfg.Workspaces[name]
+		for _, raw := range ws.Paths {
+			expanded, err := expandPath(raw)
+			if err != nil {
+				continue
+			}
+			p, err := filepath.Abs(expanded)
+			if err != nil {
+				continue
+			}
 			if pathMatchesCWD(p, cwd) && pathSegments(p) > bestSegments {
-				bestWs = resolved
+				bestName = name
 				bestMatchedPath = p
 				bestSegments = pathSegments(p)
 			}
 		}
 	}
 
-	if bestWs == nil {
-		return nil, "", fmt.Errorf("no workspace matches path %s", cwd)
+	if bestName == "" {
+		return nil, "", fmt.Errorf("no workspace matches directory %q", cwd)
 	}
 
-	return bestWs, bestMatchedPath, nil
+	resolved, err := Resolve(cfg, bestName)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve workspace %q: %w", bestName, err)
+	}
+
+	return resolved, bestMatchedPath, nil
 }
 
 func PortForWorkspace(cfg *config.Config, name string) int {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -130,7 +130,7 @@ func dedupEnvByKeyLastWins(entries []string) []string {
 func ResolveFromCWD(cfg *config.Config, cwd string) (*Resolved, string, error) {
 	var bestWs *Resolved
 	var bestMatchedPath string
-	var bestPathLen int
+	var bestSegments int
 
 	for _, name := range workspaceNames(cfg) {
 		resolved, err := Resolve(cfg, name)
@@ -138,10 +138,10 @@ func ResolveFromCWD(cfg *config.Config, cwd string) (*Resolved, string, error) {
 			continue
 		}
 		for _, p := range resolved.Paths {
-			if pathMatchesCWD(p, cwd) && len(p) > bestPathLen {
+			if pathMatchesCWD(p, cwd) && pathSegments(p) > bestSegments {
 				bestWs = resolved
 				bestMatchedPath = p
-				bestPathLen = len(p)
+				bestSegments = pathSegments(p)
 			}
 		}
 	}
@@ -173,6 +173,12 @@ func MatchesCWD(ws *Resolved, cwd string) bool {
 		}
 	}
 	return false
+}
+
+// pathSegments returns the number of non-empty segments in a filepath.
+// For example, "/a/b/c" returns 3, "/a/bb" returns 2.
+func pathSegments(p string) int {
+	return len(strings.Split(strings.Trim(p, string(filepath.Separator)), string(filepath.Separator)))
 }
 
 func pathMatchesCWD(base, cwd string) bool {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -186,9 +186,13 @@ func MatchesCWD(ws *Resolved, cwd string) bool {
 }
 
 // pathSegments returns the number of non-empty segments in a filepath.
-// For example, "/a/b/c" returns 3, "/a/bb" returns 2.
+// For example, "/a/b/c" returns 3, "/a/bb" returns 2, "/" returns 0.
 func pathSegments(p string) int {
-	return len(strings.Split(strings.Trim(p, string(filepath.Separator)), string(filepath.Separator)))
+	trimmed := strings.Trim(p, string(filepath.Separator))
+	if trimmed == "" {
+		return 0
+	}
+	return len(strings.Split(trimmed, string(filepath.Separator)))
 }
 
 func pathMatchesCWD(base, cwd string) bool {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,11 @@ import (
 
 	"github.com/seznam/jailoc/internal/config"
 )
+
+// ErrNoMatch is returned by ResolveFromCWD when no workspace has a path
+// matching the given directory. Callers can use errors.Is to distinguish
+// this from real configuration/resolution failures.
+var ErrNoMatch = errors.New("no matching workspace")
 
 // BasePort is the internal port that opencode serve binds to inside the container.
 // Host-side ports are assigned as BasePort + alphabetical workspace index.
@@ -152,7 +158,7 @@ func ResolveFromCWD(cfg *config.Config, cwd string) (*Resolved, string, error) {
 	}
 
 	if bestName == "" {
-		return nil, "", fmt.Errorf("no workspace matches directory %q", cwd)
+		return nil, "", fmt.Errorf("%w: directory %q", ErrNoMatch, cwd)
 	}
 
 	resolved, err := Resolve(cfg, bestName)

--- a/internal/workspace/workspace_internal_test.go
+++ b/internal/workspace/workspace_internal_test.go
@@ -1,0 +1,27 @@
+package workspace
+
+import "testing"
+
+func TestPathSegments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want int
+	}{
+		{"/a/b/c", 3},
+		{"/a/bb", 2},
+		{"/a", 1},
+		{"/", 0},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			if got := pathSegments(tt.path); got != tt.want {
+				t.Fatalf("pathSegments(%q) = %d, want %d", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -96,6 +96,121 @@ func TestResolveFromCWDNoMatch(t *testing.T) {
 	}
 }
 
+func TestResolveFromCWD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		cfg             *config.Config
+		cwd             string
+		wantWorkspace   string
+		wantMatchedPath string
+		wantErrContains string
+	}{
+		{
+			name: "overlapping paths uses longest prefix",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"broad": {
+						Paths: []string{"/a/b"},
+					},
+					"specific": {
+						Paths: []string{"/a/b/c"},
+					},
+				},
+			},
+			cwd:             "/a/b/c/d",
+			wantWorkspace:   "specific",
+			wantMatchedPath: "/a/b/c",
+		},
+		{
+			name: "multiple paths per workspace picks longest matched path",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"multi": {
+						Paths: []string{"/a/b", "/a/b/c/d"},
+					},
+				},
+			},
+			cwd:             "/a/b/c/d/e",
+			wantWorkspace:   "multi",
+			wantMatchedPath: "/a/b/c/d",
+		},
+		{
+			name: "equal length tiebreaker uses alphabetical workspace name",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"beta": {
+						Paths: []string{"/a/b"},
+					},
+					"alpha": {
+						Paths: []string{"/a/b"},
+					},
+				},
+			},
+			cwd:             "/a/b/c",
+			wantWorkspace:   "alpha",
+			wantMatchedPath: "/a/b",
+		},
+		{
+			name: "single match no overlap unchanged",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"alpha": {
+						Paths: []string{"/x/y"},
+					},
+					"beta": {
+						Paths: []string{"/a/b"},
+					},
+				},
+			},
+			cwd:             "/x/y/z",
+			wantWorkspace:   "alpha",
+			wantMatchedPath: "/x/y",
+		},
+		{
+			name: "no-match",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"default": {
+						Paths: []string{"/home/user/projects"},
+					},
+				},
+			},
+			cwd:             "/unrelated/path",
+			wantErrContains: "no workspace matches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resolved, matchedPath, err := workspace.ResolveFromCWD(tt.cfg, tt.cwd)
+
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ResolveFromCWD returned error: %v", err)
+			}
+			if resolved.Name != tt.wantWorkspace {
+				t.Fatalf("workspace mismatch: got %q want %q", resolved.Name, tt.wantWorkspace)
+			}
+			if matchedPath != tt.wantMatchedPath {
+				t.Fatalf("matched path mismatch: got %q want %q", matchedPath, tt.wantMatchedPath)
+			}
+		})
+	}
+}
+
 func TestPortAllocationAlphabetical(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -153,6 +153,22 @@ func TestResolveFromCWD(t *testing.T) {
 			wantMatchedPath: "/a/b",
 		},
 		{
+			name: "segment count wins over string length",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"long-name": {
+						Paths: []string{"/a/bb"},
+					},
+					"deep": {
+						Paths: []string{"/a/b/c"},
+					},
+				},
+			},
+			cwd:             "/a/b/c/d",
+			wantWorkspace:   "deep",
+			wantMatchedPath: "/a/b/c",
+		},
+		{
 			name: "single match no overlap unchanged",
 			cfg: &config.Config{
 				Workspaces: map[string]config.Workspace{

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -91,7 +91,7 @@ func TestResolveFromCWDNoMatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected no match error")
 	}
-	if !strings.Contains(err.Error(), "no workspace matches") {
+	if !strings.Contains(err.Error(), "no matching workspace") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -194,7 +194,7 @@ func TestResolveFromCWD(t *testing.T) {
 				},
 			},
 			cwd:             "/unrelated/path",
-			wantErrContains: "no workspace matches",
+			wantErrContains: "no matching workspace",
 		},
 	}
 
@@ -1015,7 +1015,7 @@ func TestResolveFromCWDErrorMessages(t *testing.T) {
 				},
 			},
 			cwd:         "/unrelated/path",
-			wantSubstrs: []string{"/unrelated/path", "no workspace matches"},
+			wantSubstrs: []string{"/unrelated/path", "no matching workspace"},
 		},
 		{
 			name: "empty workspaces map includes directory",
@@ -1023,7 +1023,7 @@ func TestResolveFromCWDErrorMessages(t *testing.T) {
 				Workspaces: map[string]config.Workspace{},
 			},
 			cwd:         "/some/path",
-			wantSubstrs: []string{"/some/path", "no workspace matches"},
+			wantSubstrs: []string{"/some/path", "no matching workspace"},
 		},
 		{
 			name: "all workspaces have empty paths includes directory",
@@ -1034,7 +1034,7 @@ func TestResolveFromCWDErrorMessages(t *testing.T) {
 				},
 			},
 			cwd:         "/anywhere",
-			wantSubstrs: []string{"/anywhere", "no workspace matches"},
+			wantSubstrs: []string{"/anywhere", "no matching workspace"},
 		},
 	}
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -943,3 +943,116 @@ func TestResolveImagePropagation(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		workspace   string
+		wantSubstrs []string
+	}{
+		{
+			name:        "nil config includes workspace name",
+			cfg:         nil,
+			workspace:   "myws",
+			wantSubstrs: []string{"myws", "not found"},
+		},
+		{
+			name: "nonexistent workspace includes name",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"other": {Paths: []string{"/data"}},
+				},
+			},
+			workspace:   "missing",
+			wantSubstrs: []string{"missing", "not found"},
+		},
+		{
+			name: "empty workspaces map includes name",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{},
+			},
+			workspace:   "default",
+			wantSubstrs: []string{"default", "not found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := workspace.Resolve(tt.cfg, tt.workspace)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			msg := err.Error()
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error %q missing expected substring %q", msg, sub)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveFromCWDErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		cwd         string
+		wantSubstrs []string
+	}{
+		{
+			name: "no matching workspace includes directory",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"default": {Paths: []string{"/home/user/projects"}},
+				},
+			},
+			cwd:         "/unrelated/path",
+			wantSubstrs: []string{"/unrelated/path", "no workspace matches"},
+		},
+		{
+			name: "empty workspaces map includes directory",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{},
+			},
+			cwd:         "/some/path",
+			wantSubstrs: []string{"/some/path", "no workspace matches"},
+		},
+		{
+			name: "all workspaces have empty paths includes directory",
+			cfg: &config.Config{
+				Workspaces: map[string]config.Workspace{
+					"default": {Paths: []string{}},
+					"other":   {Paths: []string{}},
+				},
+			},
+			cwd:         "/anywhere",
+			wantSubstrs: []string{"/anywhere", "no workspace matches"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := workspace.ResolveFromCWD(tt.cfg, tt.cwd)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			msg := err.Error()
+			for _, sub := range tt.wantSubstrs {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error %q missing expected substring %q", msg, sub)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `ResolveFromCWD` picks the workspace with the longest matching path prefix (by segment count, alphabetical tiebreaker) — resolves only the winner, propagating errors instead of silently skipping
- All commands (`up`, `down`, `logs`, `status`, `add`, root) auto-detect the workspace from CWD when `--workspace` is not explicitly set, falling back to `default`
- `add` returns an error when explicit `-w` conflicts with the target path; root uses the existing "add path?" prompt
- Removed `attach` subcommand — root command covers all its functionality (auto-start, auto-add, attach)

## Changes

- `internal/workspace/workspace.go` — `ResolveFromCWD` with longest-prefix match on raw expanded paths, `pathSegments` helper
- `internal/workspace/workspace_test.go` — 6 test cases (overlapping paths, ties, no-match, multi-path, single match, segment count vs string length)
- `internal/cmd/root.go` — `workspaceExplicit` bool via `PersistentPreRunE`, CWD auto-detect for root command
- `internal/cmd/{up,down,status}.go` — CWD auto-detect before `workspace.Resolve`
- `internal/cmd/logs.go` — CWD fallback when no positional arg and no explicit `-w`
- `internal/cmd/add.go` — auto-detect from target path + conflict detection with explicit `-w`
- `internal/cmd/attach.go` — removed `attachCmd`, `runAttach`, kept shared helpers used by root
- `docs/` — updated 7 doc files to reflect attach removal and auto-detection behavior