### PR TITLE
fix(podman): whitelist DNS resolvers and collapse networks for Podman compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ No dependency cycles. Shared types cross package boundaries: `config.Config`, `c
 
 ### Container architecture
 
-Two services per workspace on an internal Docker network:
+Two services per workspace on a shared Docker network:
 
 - **opencode container**: runs `opencode serve` as UID 1000 (agent), workspace paths bind-mounted (rw), OC config mounted (ro), port exposed to host
 - **dind container**: privileged Docker daemon on TLS :2376, shared TLS certs + docker data via named volumes

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -20,21 +20,17 @@ flowchart TB
     end
   end
 
-  oc -.- dind_net["dind network (internal)"]
-  dind -.- dind_net
-  oc -.- egress_net["egress network (external)"]
+  oc -.- net["jailoc network"]
+    dind -.- net
 ```
 
 The **opencode container** is where the agent lives. It runs `opencode serve` as UID 1000 (a non-root user named `agent`), exposes a port to the host for attaching a terminal, and has your workspace paths mounted read-write. Your OpenCode configuration is mounted read-only so the agent inherits your API keys and settings without being able to modify them on the host.
 
 The **dind container** runs a full Docker daemon in privileged mode. It exists solely to give the agent access to Docker without sharing the host's socket. The daemon listens on port 2376 with mutual TLS authentication, and the certificates are shared with the opencode container via a named volume. When the agent runs `docker build` or starts a database for testing, those containers exist entirely within the dind daemon's scope and are invisible to the host.
 
-## Two networks
+## Network
 
-The Compose project attaches containers to two networks:
-
-- The **dind network** is marked `internal: true`, meaning no host-routed traffic flows through it. It carries only the TLS connection between the opencode container and the dind daemon. Setting it internal ensures the dind daemon itself isn't reachable from outside the project.
-- The **egress network** connects the opencode container to the outside world. Traffic on this network is subject to the iptables rules set up during container startup.
+Both containers share a single Docker network named `jailoc`. The opencode container communicates with the dind daemon over this network via TLS on port 2376, and the same network carries the opencode container's egress traffic to the outside world. Network isolation is handled by iptables rules inside the opencode container rather than by network-level separation — see [Network Isolation](network-isolation.md) for details.
 
 ## Volume mounts
 
@@ -73,7 +69,7 @@ The three-phase sequence matters because iptables manipulation and `chown` both 
 
 ## Why privileged dind?
 
-Nested Docker requires the `--privileged` flag because it needs to mount cgroups, load kernel modules, and use `overlay2` as a storage driver. There's no way around this with current Linux kernel capabilities. The tradeoff is accepted deliberately: the dind container is privileged, but it's on an internal network, has no access to host paths, and its daemon is only reachable from the opencode container over mutual TLS.
+Nested Docker requires the `--privileged` flag because it needs to mount cgroups, load kernel modules, and use `overlay2` as a storage driver. There's no way around this with current Linux kernel capabilities. The tradeoff is accepted deliberately: the dind container is privileged, but it has no access to host paths, and its daemon is only reachable from the opencode container over mutual TLS.
 
 For instructions on configuring which hosts the agent can reach, see [How-to: Network Access](../how-to/network-access.md).
 

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -53,7 +53,7 @@ Environment variables configured via `env` or `env_file` in the workspace config
 
 The entrypoint script is bind-mounted into the container at runtime by jailoc and runs as root. It performs three distinct phases before handing off to the agent process.
 
-**Phase 1: Network rules.** The script installs iptables rules that shape what the agent can reach. It inserts ACCEPT rules for the dind container, the host gateway, and any hosts or networks you've allowed in config. It then appends DROP rules for RFC 1918 address space, link-local addresses, and CGNAT ranges. Public internet traffic is untouched. See [Network Isolation](network-isolation.md) for a full explanation of the security model.
+**Phase 1: Network rules.** The script installs iptables rules that shape what the agent can reach. It inserts ACCEPT rules for the dind container, the host gateway, DNS resolver addresses (port 53 only), and any hosts or networks you've allowed in config. It appends an ACCEPT rule for TCP replies on the published service port so that port-forwarded connections from the host can complete. It then appends DROP rules for RFC 1918 address space, link-local addresses, and CGNAT ranges. Public internet traffic is untouched. See [Network Isolation](network-isolation.md) for a full explanation of the security model.
 
 **Phase 2: Ownership fix.** Named volumes are created by Docker as root. The entrypoint runs `chown` on the data directories so UID 1000 can write to them once the privilege drop happens. If an SSH agent socket is mounted, its ownership is adjusted to UID 1000 as well. If the `~/.ssh` directory exists (from the known hosts mount), it is recursively owned to UID 1000.
 

--- a/docs/explanation/network-isolation.md
+++ b/docs/explanation/network-isolation.md
@@ -34,7 +34,7 @@ For step-by-step instructions, see [How-to: Network Access](../how-to/network-ac
 
 ## The dind sidecar is a special case
 
-The dind container runs on the internal Docker network, not the egress network. iptables rules in the opencode container control egress from that container — they don't apply to the dind container at all. The dind daemon is isolated differently: it's on a network marked `internal: true`, which means Docker prevents host-routed traffic from reaching it. It's only reachable from within the Compose project.
+The dind container shares the same Docker network as the opencode container. iptables rules in the opencode container control egress from that container — they don't apply to the dind container at all. The dind daemon listens on port 2376 with mutual TLS, so only the opencode container (which holds the client certificates) can connect to it.
 
 Any containers the agent starts through dind inherit the dind daemon's network configuration, not the opencode container's iptables rules. If an agent-started container needs to reach a specific address, that's determined by dind's setup, not by jailoc's iptables. This is a deliberate tradeoff: the agent's direct network is controlled, but containers-within-containers operate outside that control layer.
 

--- a/docs/explanation/network-isolation.md
+++ b/docs/explanation/network-isolation.md
@@ -28,6 +28,10 @@ Three things always get ACCEPT rules regardless of your config:
 2. The host gateway (so DNS and the Docker bridge work)
 3. Any hosts or networks you've explicitly allowed in your workspace config
 
+DNS resolver addresses from `/etc/resolv.conf` also get ACCEPT rules, but only for port 53 (UDP and TCP). This is necessary because some container runtimes (notably Podman) place the DNS resolver at an address inside a blocked private range. Without this rule, hostname resolution would fail and the allowed-hosts mechanism would be useless. The rule is scoped to port 53 so the resolver IP cannot be used as a general-purpose gateway into the private network.
+
+A final ACCEPT rule allows TCP replies on the published service port (4096) for connections that were initiated from outside the container. This exists because port-forwarded traffic from the host arrives with a source address in a private range — without this rule, the container's reply packets would hit the DROP rules and the connection would hang. The rule is scoped to established TCP connections on the service port only, so it does not open any new outbound paths.
+
 If you need the agent to reach an internal service, adding it to `allowed_hosts` or `allowed_networks` in your workspace config causes an ACCEPT rule to be inserted before the DROP rules fire. The agent can then reach that specific address while everything else in the private range stays blocked.
 
 For step-by-step instructions, see [How-to: Network Access](../how-to/network-access.md).

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -59,8 +59,7 @@ services:
     cpus: 2.0
     pids_limit: 256
     networks:
-      - dind
-      - egress
+      - jailoc
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     command: ["opencode", "serve", "--hostname", "0.0.0.0", "--port", "4096", "--print-logs", "--log-level", "DEBUG"]
 {{- if .Paths}}
@@ -99,8 +98,7 @@ services:
       - 1.1.1.1
       - 8.8.8.8
     networks:
-      - dind
-      - egress
+      - jailoc
     expose:
       - "2376"
 
@@ -112,6 +110,4 @@ volumes:
   dind-data:
 
 networks:
-  dind:
-    internal: true
-  egress:
+  jailoc:

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -52,6 +52,9 @@ if [ -f "$ALLOWED_NETWORKS" ]; then
   done < "$ALLOWED_NETWORKS"
 fi
 
+# --- Allow replies to inbound connections (e.g. port-forwarded traffic) ---
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
 # --- Block private/internal networks ---
 iptables -A OUTPUT -d 10.0.0.0/8 -j DROP
 iptables -A OUTPUT -d 172.16.0.0/12 -j DROP

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -60,8 +60,8 @@ if [ -f "$ALLOWED_NETWORKS" ]; then
   done < "$ALLOWED_NETWORKS"
 fi
 
-# --- Allow replies to inbound connections (e.g. port-forwarded traffic) ---
-iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+# --- Allow replies to inbound connections on the published service port ---
+iptables -A OUTPUT -p tcp --sport 4096 -m conntrack --ctstate ESTABLISHED -j ACCEPT
 
 # --- Block private/internal networks ---
 iptables -A OUTPUT -d 10.0.0.0/8 -j DROP

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -34,10 +34,18 @@ if [ -f "$ALLOWED_HOSTS" ]; then
   done < "$ALLOWED_HOSTS"
 fi
 
-# --- Allow DNS resolvers ---
-while read -r key value _; do
-  [ "$key" = "nameserver" ] && iptables -I OUTPUT -d "$value" -j ACCEPT
-done < /etc/resolv.conf
+# --- Allow DNS resolvers (port 53 only) ---
+if [ -f /etc/resolv.conf ]; then
+  while read -r key value _; do
+    if [ "$key" = "nameserver" ]; then
+      if [[ "$value" == *:* ]]; then
+        continue
+      fi
+      iptables -I OUTPUT -p udp -d "$value" --dport 53 -j ACCEPT
+      iptables -I OUTPUT -p tcp -d "$value" --dport 53 -j ACCEPT
+    fi
+  done < /etc/resolv.conf
+fi
 
 # --- Allow CIDR networks from config ---
 ALLOWED_NETWORKS="/etc/jailoc/allowed-networks"

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -34,6 +34,11 @@ if [ -f "$ALLOWED_HOSTS" ]; then
   done < "$ALLOWED_HOSTS"
 fi
 
+# --- Allow DNS resolvers ---
+while read -r key value _; do
+  [ "$key" = "nameserver" ] && iptables -I OUTPUT -d "$value" -j ACCEPT
+done < /etc/resolv.conf
+
 # --- Allow CIDR networks from config ---
 ALLOWED_NETWORKS="/etc/jailoc/allowed-networks"
 if [ -f "$ALLOWED_NETWORKS" ]; then


### PR DESCRIPTION
## Summary

Two fixes for Podman compatibility:

### DNS resolver whitelisting
- Podman's DNS resolver (e.g. `192.168.127.1`) falls within the `192.168.0.0/16` DROP range, breaking all hostname resolution inside the container
- Docker's embedded DNS (`127.0.0.11`) is in loopback space and unaffected — this only manifests under Podman
- Parse `/etc/resolv.conf` nameservers and whitelist them via `iptables -I OUTPUT` before the DROP rules

### Single network (replaces dual dind+egress)
- Podman/netavark has a [known bug](https://github.com/containers/podman/issues/27349) where port forwarding fails for containers attached to multiple networks when one has `internal: true`
- The dual-network setup (`dind` internal + `egress`) provided no additional security — both containers were on both networks, and the actual hardening comes from iptables OUTPUT rules + `setpriv` privilege drop
- Collapse to a single `jailoc` network — fixes port forwarding on Podman, no security regression on Docker