### PR TITLE
feat: configurable cpu and memory resource limits

### DIFF
--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -27,6 +27,8 @@ flowchart TB
 
 The **opencode container** is where the agent lives. It runs `opencode serve` as UID 1000 (a non-root user named `agent`), exposes a port to the host for attaching a terminal, and has your workspace paths mounted read-write. Your OpenCode configuration is mounted read-only so the agent inherits your API keys and settings without being able to modify them on the host.
 
+The opencode container runs with configurable resource limits. The `cpu` (default 2 cores) and `memory` (default 4 GB) settings control how much of the host's resources the container can consume, and are configurable per workspace via the TOML config. Other resource limits — `pids_limit` (256) and `mem_reservation` (512 MB) — are fixed and not configurable. Resource limit changes take effect on the next `jailoc up` invocation; running containers are not affected until restarted.
+
 The **dind container** runs a full Docker daemon in privileged mode. It exists solely to give the agent access to Docker without sharing the host's socket. The daemon listens on port 2376 with mutual TLS authentication, and the certificates are shared with the opencode container via a named volume. When the agent runs `docker build` or starts a database for testing, those containers exist entirely within the dind daemon's scope and are invisible to the host.
 
 ## Two networks

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -203,3 +203,21 @@ ssh_auth_sock = true
 ```
 
 These can also be set per-workspace. See [How to pass through SSH and Git config](ssh-git-passthrough.md) for details.
+
+---
+
+## Set resource limits
+
+Control the CPU and memory allocated to the opencode container with `cpu` and `memory`:
+
+```toml
+[defaults]
+cpu = 2.0
+memory = "4g"
+
+[workspaces.heavy-agent]
+cpu = 8.0
+memory = "16g"
+```
+
+Both fields are optional. Workspace values override defaults; when neither is set, the fallback is `2.0` CPU cores and `"4g"` memory. The `memory` field accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` (e.g. `512m`, `4g`, `1024`).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,6 +43,8 @@ Global defaults applied to all workspaces. All fields are optional and default t
 | `allowed_networks` | string[] | `[]` | CIDR ranges allowed through the firewall for all workspaces. Merged with per-workspace `allowed_networks`. |
 | `ssh_auth_sock` | bool | `false` | Mount the host SSH agent socket into the container. Auto-detects the socket: Docker Desktop/OrbStack magic path first, then `$SSH_AUTH_SOCK`. Also mounts `~/.ssh/known_hosts` read-only when enabled. |
 | `git_config` | bool | `true` | Mount the host Git configuration (`~/.gitconfig` or `~/.config/git/config`) read-only into the container. |
+| `cpu` | float64 | `2.0` | Number of CPU cores allocated to the opencode container. Must be greater than 0. |
+| `memory` | string | `"4g"` | Memory limit for the opencode container. Accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` suffix (e.g. `512m`, `4g`, `1024`). Must be greater than 0. |
 
 ### Example
 
@@ -55,6 +57,8 @@ allowed_hosts = ["internal-registry.example.com"]
 allowed_networks = ["10.0.0.0/8"]
 ssh_auth_sock = true
 git_config = true
+cpu = 4.0
+memory = "8g"
 ```
 
 ---
@@ -78,6 +82,8 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | `env_file` | string[] | `[]` | Paths to `.env` files for this workspace. Each file must exist at config load time. Paths must be absolute (`/...`) or start with `~`. Loaded after global `defaults.env_file` entries. |
 | `ssh_auth_sock` | bool | (inherit) | Mount the host SSH agent socket into the container. When not set, inherits from `[defaults]`. Also mounts `~/.ssh/known_hosts` read-only when enabled. |
 | `git_config` | bool | (inherit) | Mount the host Git configuration read-only into the container. When not set, inherits from `[defaults]`. Falls back to `true` when neither the workspace nor defaults set it. |
+| `cpu` | float64 | (inherit) | Number of CPU cores allocated to the opencode container. When not set, inherits from `[defaults]`. Falls back to `2.0` when neither the workspace nor defaults set it. |
+| `memory` | string | (inherit) | Memory limit for the opencode container. When not set, inherits from `[defaults]`. Falls back to `"4g"` when neither the workspace nor defaults set it. |
 
 !!! note
     `image` is mutually exclusive with `dockerfile` and `build_context`. Setting `image` alongside either of those fields is a validation error.
@@ -130,6 +136,14 @@ The workspace `image` field is mutually exclusive with `dockerfile` and `build_c
 - `image` set together with `dockerfile`
 - `image` set together with `build_context`
 
+### `cpu`
+
+Must be a positive number (greater than 0). Applies to both `[defaults]` and workspace sections. Zero and negative values are rejected at config load time.
+
+### `memory`
+
+Must match the regular expression `^[1-9][0-9]*[kmgKMG]?$` — a positive integer optionally followed by a `k`, `m`, or `g` suffix (case-insensitive). Examples: `512m`, `4g`, `1024`. Values like `0`, `0m`, or empty strings are rejected at config load time.
+
 ### `dockerfile` fields
 
 Accepted values:
@@ -178,6 +192,8 @@ Environment variables from multiple sources are merged in this order (later entr
 `allowed_hosts` and `allowed_networks` use union deduplication: the global list is merged with the workspace list, with duplicates removed, preserving order.
 
 `ssh_auth_sock` and `git_config` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config` falls back to `true` when neither the workspace nor defaults set it.
+
+`cpu` and `memory` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `cpu` falls back to `2.0` and `memory` falls back to `"4g"` when neither the workspace nor defaults set them.
 
 ---
 

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -88,7 +88,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 
 	defaultsCPU := "(not set, default: 2.0)"
 	if cfg.Defaults.CPU != nil {
-		defaultsCPU = fmt.Sprintf("%.1f", *cfg.Defaults.CPU)
+		defaultsCPU = fmt.Sprintf("%g", *cfg.Defaults.CPU)
 	}
 	_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "Defaults CPU: %s\n", defaultsCPU)
 
@@ -171,7 +171,7 @@ func runConfig(cmd *cobra.Command, args []string) error {
 
 		wsCPU := "(not set)"
 		if ws.CPU != nil {
-			wsCPU = fmt.Sprintf("%.1f", *ws.CPU)
+			wsCPU = fmt.Sprintf("%g", *ws.CPU)
 		}
 		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  CPU: %s\n", wsCPU)
 

--- a/internal/cmd/config_cmd.go
+++ b/internal/cmd/config_cmd.go
@@ -86,6 +86,18 @@ func runConfig(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	defaultsCPU := "(not set, default: 2.0)"
+	if cfg.Defaults.CPU != nil {
+		defaultsCPU = fmt.Sprintf("%.1f", *cfg.Defaults.CPU)
+	}
+	_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "Defaults CPU: %s\n", defaultsCPU)
+
+	defaultsMemory := "(not set, default: 4g)"
+	if cfg.Defaults.Memory != nil {
+		defaultsMemory = *cfg.Defaults.Memory
+	}
+	_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "Defaults Memory: %s\n", defaultsMemory)
+
 	_, _ = fmt.Fprintf(os.Stdout, "\n")
 
 	// Print each workspace
@@ -156,6 +168,18 @@ func runConfig(cmd *cobra.Command, args []string) error {
 				_, _ = fmt.Fprintf(os.Stdout, "    - %s\n", f)
 			}
 		}
+
+		wsCPU := "(not set)"
+		if ws.CPU != nil {
+			wsCPU = fmt.Sprintf("%.1f", *ws.CPU)
+		}
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  CPU: %s\n", wsCPU)
+
+		wsMemory := "(not set)"
+		if ws.Memory != nil {
+			wsMemory = *ws.Memory
+		}
+		_, _ = color.New(color.FgCyan).Fprintf(os.Stdout, "  Memory: %s\n", wsMemory)
 
 		_, _ = fmt.Fprintf(os.Stdout, "\n")
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -105,6 +105,8 @@ func runUp(ctx context.Context, args []string) error {
 		SSHAuthSock:      resolveSSHAuthSock(ws.SSHAuthSock),
 		SSHKnownHosts:    resolveSSHKnownHosts(ws.SSHAuthSock),
 		GitConfig:        resolveGitConfig(ws.GitConfig),
+		CPU:              ws.CPU,
+		Memory:           ws.Memory,
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Generating compose configuration...\n")

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -22,6 +22,8 @@ type ComposeParams struct {
 	SSHAuthSock      string // host socket path to mount, empty = disabled
 	SSHKnownHosts    string // host known_hosts path to mount (bound to SSHAuthSock), empty = disabled
 	GitConfig        string // host gitconfig path to mount, empty = disabled
+	CPU              float64
+	Memory           string
 }
 
 func GenerateCompose(params ComposeParams) ([]byte, error) {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -17,6 +17,8 @@ func TestGenerateComposeSinglePath(t *testing.T) {
 		Paths:            []string{"/Users/test/work/project"},
 		OpenCodePassword: "secret",
 		Env:              nil,
+		CPU:              2.0,
+		Memory:           "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -51,7 +53,9 @@ func TestGenerateComposeMultiplePaths(t *testing.T) {
 			"/repos/api",
 			"/repos/web-app",
 		},
-		Env: nil,
+		Env:    nil,
+		CPU:    2.0,
+		Memory: "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -75,6 +79,8 @@ func TestGenerateComposeEmptyPasswordRendersEmptyValue(t *testing.T) {
 		Image:         "ghcr.io/seznam/jailoc:dev",
 		Paths:         []string{"/tmp/work"},
 		Env:           nil,
+		CPU:           2.0,
+		Memory:        "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -99,6 +105,8 @@ func TestGenerateComposeVolumeNamesIncludeWorkspaceName(t *testing.T) {
 		Image:         "ghcr.io/seznam/jailoc:main",
 		Paths:         []string{"/tmp/repo"},
 		Env:           nil,
+		CPU:           2.0,
+		Memory:        "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -124,6 +132,8 @@ func TestWriteComposeFileHappyPath(t *testing.T) {
 		Paths:            []string{"/tmp/workspace"},
 		OpenCodePassword: "testpass",
 		Env:              nil,
+		CPU:              2.0,
+		Memory:           "4g",
 	}
 
 	destPath := filepath.Join(t.TempDir(), "docker-compose.yml")
@@ -165,6 +175,8 @@ func TestWriteComposeFileErrorPath(t *testing.T) {
 		Image:         "ghcr.io/seznam/jailoc:test",
 		Paths:         []string{"/tmp/workspace"},
 		Env:           nil,
+		CPU:           2.0,
+		Memory:        "4g",
 	}
 
 	destPath := "/nonexistent/directory/docker-compose.yml"
@@ -198,6 +210,8 @@ func TestGenerateComposeSSHAuthSock(t *testing.T) {
 			Paths:            []string{"/tmp/work"},
 			OpenCodePassword: "secret",
 			SSHAuthSock:      "/run/host-services/ssh-auth.sock",
+			CPU:              2.0,
+			Memory:           "4g",
 		}
 
 		out, err := GenerateCompose(params)
@@ -219,6 +233,8 @@ func TestGenerateComposeSSHAuthSock(t *testing.T) {
 			Paths:            []string{"/tmp/work"},
 			OpenCodePassword: "secret",
 			SSHAuthSock:      "",
+			CPU:              2.0,
+			Memory:           "4g",
 		}
 
 		out, err := GenerateCompose(params)
@@ -248,6 +264,8 @@ func TestGenerateComposeGitConfig(t *testing.T) {
 			Paths:            []string{"/tmp/work"},
 			OpenCodePassword: "secret",
 			GitConfig:        "/home/user/.gitconfig",
+			CPU:              2.0,
+			Memory:           "4g",
 		}
 
 		out, err := GenerateCompose(params)
@@ -268,6 +286,8 @@ func TestGenerateComposeGitConfig(t *testing.T) {
 			Paths:            []string{"/tmp/work"},
 			OpenCodePassword: "secret",
 			GitConfig:        "",
+			CPU:              2.0,
+			Memory:           "4g",
 		}
 
 		out, err := GenerateCompose(params)
@@ -294,6 +314,8 @@ func TestGenerateComposeSSHKnownHosts(t *testing.T) {
 			Paths:            []string{"/tmp/work"},
 			OpenCodePassword: "secret",
 			SSHKnownHosts:    "/home/user/.ssh/known_hosts",
+			CPU:              2.0,
+			Memory:           "4g",
 		}
 
 		out, err := GenerateCompose(params)
@@ -314,6 +336,8 @@ func TestGenerateComposeSSHKnownHosts(t *testing.T) {
 			Paths:            []string{"/tmp/work"},
 			OpenCodePassword: "secret",
 			SSHKnownHosts:    "",
+			CPU:              2.0,
+			Memory:           "4g",
 		}
 
 		out, err := GenerateCompose(params)
@@ -340,6 +364,8 @@ func TestGenerateComposeAllSSHGitEnabled(t *testing.T) {
 		SSHAuthSock:      "/run/host-services/ssh-auth.sock",
 		GitConfig:        "/home/user/.gitconfig",
 		SSHKnownHosts:    "/home/user/.ssh/known_hosts",
+		CPU:              2.0,
+		Memory:           "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -364,6 +390,8 @@ func TestGenerateComposeEnv(t *testing.T) {
 		Paths:            []string{"/tmp/work"},
 		OpenCodePassword: "secret",
 		Env:              []string{"MY_VAR=hello", "OTHER=world"},
+		CPU:              2.0,
+		Memory:           "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -393,6 +421,8 @@ func TestGenerateComposeEmptyEnv(t *testing.T) {
 		Paths:            []string{"/tmp/work"},
 		OpenCodePassword: "secret",
 		Env:              nil,
+		CPU:              2.0,
+		Memory:           "4g",
 	}
 
 	out, err := GenerateCompose(params)
@@ -421,5 +451,111 @@ func TestGenerateComposeEmptyEnv(t *testing.T) {
 		if !strings.HasPrefix(afterEnv, "      -") {
 			t.Errorf("expected environment entry starting with '      -', got: %q", afterEnv)
 		}
+	}
+}
+
+func TestComposeResourceLimits(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "test",
+		Port:          4096,
+		Image:         "ubuntu:22.04",
+		Paths:         []string{"/data/workspace"},
+		CPU:           2.0,
+		Memory:        "4g",
+	}
+
+	rendered, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose failed: %v", err)
+	}
+
+	assertContains(t, string(rendered), "mem_limit: 4g")
+	assertContains(t, string(rendered), "memswap_limit: 4g")
+	assertContains(t, string(rendered), "cpus: 2.0")
+	assertContains(t, string(rendered), "mem_reservation: 512m")
+	assertContains(t, string(rendered), "pids_limit: 256")
+}
+
+func TestComposeCustomResourceLimits(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "test",
+		Port:          4096,
+		Image:         "ubuntu:22.04",
+		Paths:         []string{"/data/workspace"},
+		CPU:           4.0,
+		Memory:        "8g",
+	}
+
+	rendered, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose failed: %v", err)
+	}
+
+	assertContains(t, string(rendered), "mem_limit: 8g")
+	assertContains(t, string(rendered), "memswap_limit: 8g")
+	assertContains(t, string(rendered), "cpus: 4.0")
+	// Old values must NOT be present
+	if strings.Contains(string(rendered), "mem_limit: 4g") {
+		t.Error("expected custom mem_limit: 8g, found old value mem_limit: 4g")
+	}
+}
+
+func TestComposeResourceLimitsFractionalCPU(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "test",
+		Port:          4096,
+		Image:         "ubuntu:22.04",
+		Paths:         []string{"/data/workspace"},
+		CPU:           1.5,
+		Memory:        "512m",
+	}
+
+	rendered, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose failed: %v", err)
+	}
+
+	assertContains(t, string(rendered), "cpus: 1.5")
+	assertContains(t, string(rendered), "mem_limit: 512m")
+	assertContains(t, string(rendered), "memswap_limit: 512m")
+}
+
+func TestComposeHealthCheckTimings(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "test",
+		Port:          4096,
+		Image:         "ubuntu:22.04",
+		Paths:         []string{"/data/workspace"},
+		CPU:           2.0,
+		Memory:        "4g",
+	}
+
+	rendered, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose failed: %v", err)
+	}
+
+	assertContains(t, string(rendered), "interval: 30s")
+	assertContains(t, string(rendered), "timeout: 10s")
+	assertContains(t, string(rendered), "retries: 5")
+	assertContains(t, string(rendered), "start_period: 60s")
+
+	// Old hardcoded values must not be present
+	if strings.Contains(string(rendered), "interval: 10s") {
+		t.Error("old health check interval 10s still present")
+	}
+	if strings.Contains(string(rendered), "timeout: 5s") {
+		t.Error("old health check timeout 5s still present")
+	}
+	if strings.Contains(string(rendered), "retries: 3\n") {
+		t.Error("old health check retries: 3 still present")
 	}
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -471,9 +471,9 @@ func TestComposeResourceLimits(t *testing.T) {
 		t.Fatalf("GenerateCompose failed: %v", err)
 	}
 
-	assertContains(t, string(rendered), "mem_limit: 4g")
-	assertContains(t, string(rendered), "memswap_limit: 4g")
-	assertContains(t, string(rendered), "cpus: 2.0")
+	assertContains(t, string(rendered), `mem_limit: "4g"`)
+	assertContains(t, string(rendered), `memswap_limit: "4g"`)
+	assertContains(t, string(rendered), "cpus: 2")
 	assertContains(t, string(rendered), "mem_reservation: 512m")
 	assertContains(t, string(rendered), "pids_limit: 256")
 }
@@ -495,12 +495,12 @@ func TestComposeCustomResourceLimits(t *testing.T) {
 		t.Fatalf("GenerateCompose failed: %v", err)
 	}
 
-	assertContains(t, string(rendered), "mem_limit: 8g")
-	assertContains(t, string(rendered), "memswap_limit: 8g")
-	assertContains(t, string(rendered), "cpus: 4.0")
+	assertContains(t, string(rendered), `mem_limit: "8g"`)
+	assertContains(t, string(rendered), `memswap_limit: "8g"`)
+	assertContains(t, string(rendered), "cpus: 4")
 	// Old values must NOT be present
-	if strings.Contains(string(rendered), "mem_limit: 4g") {
-		t.Error("expected custom mem_limit: 8g, found old value mem_limit: 4g")
+	if strings.Contains(string(rendered), `mem_limit: "4g"`) {
+		t.Error(`expected custom mem_limit: "8g", found old value mem_limit: "4g"`)
 	}
 }
 
@@ -522,8 +522,8 @@ func TestComposeResourceLimitsFractionalCPU(t *testing.T) {
 	}
 
 	assertContains(t, string(rendered), "cpus: 1.5")
-	assertContains(t, string(rendered), "mem_limit: 512m")
-	assertContains(t, string(rendered), "memswap_limit: 512m")
+	assertContains(t, string(rendered), `mem_limit: "512m"`)
+	assertContains(t, string(rendered), `memswap_limit: "512m"`)
 }
 
 func TestComposeHealthCheckTimings(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,8 @@ const (
 # allowed_networks = ["10.0.0.0/8"]
 # ssh_auth_sock = false
 # git_config = true
+# cpu = 2.0
+# memory = "4g"
 
 [workspaces.default]
 paths = []
@@ -45,6 +47,8 @@ paths = []
 # dockerfile = ""
 # ssh_auth_sock = false
 # git_config = true
+# cpu = 2.0
+# memory = "4g"
 `
 )
 
@@ -54,6 +58,8 @@ const (
 )
 
 var workspaceNameRe = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+var validMemory = regexp.MustCompile(`^[1-9][0-9]*[kmgKMG]?$`)
 
 var reservedEnvKeys = map[string]bool{
 	"OPENCODE_LOG":             true,
@@ -103,6 +109,8 @@ type Defaults struct {
 	Image           string   `toml:"image"`
 	SSHAuthSock     bool     `toml:"ssh_auth_sock"`
 	GitConfig       *bool    `toml:"git_config"`
+	CPU             *float64 `toml:"cpu"`
+	Memory          *string  `toml:"memory"`
 }
 
 type Workspace struct {
@@ -116,6 +124,8 @@ type Workspace struct {
 	Image           string   `toml:"image"`
 	SSHAuthSock     *bool    `toml:"ssh_auth_sock"`
 	GitConfig       *bool    `toml:"git_config"`
+	CPU             *float64 `toml:"cpu"`
+	Memory          *string  `toml:"memory"`
 }
 
 func ConfigDir() string {
@@ -306,6 +316,13 @@ func Validate(cfg *Config) error {
 		return err
 	}
 
+	if cfg.Defaults.CPU != nil && *cfg.Defaults.CPU <= 0 {
+		return fmt.Errorf("defaults: cpu must be greater than 0")
+	}
+	if cfg.Defaults.Memory != nil && !validMemory.MatchString(*cfg.Defaults.Memory) {
+		return fmt.Errorf("defaults: invalid memory format %q: must be a positive integer optionally followed by k, m, or g (e.g. \"4g\", \"512m\")", *cfg.Defaults.Memory)
+	}
+
 	names := make([]string, 0, len(cfg.Workspaces))
 	for name := range cfg.Workspaces {
 		names = append(names, name)
@@ -369,6 +386,13 @@ func Validate(cfg *Config) error {
 		}
 		if err := validateEnvFiles(ws.EnvFile, wsContext); err != nil {
 			return err
+		}
+
+		if ws.CPU != nil && *ws.CPU <= 0 {
+			return fmt.Errorf("workspace %q: cpu must be greater than 0", name)
+		}
+		if ws.Memory != nil && !validMemory.MatchString(*ws.Memory) {
+			return fmt.Errorf("workspace %q: invalid memory format %q: must be a positive integer optionally followed by k, m, or g (e.g. \"4g\", \"512m\")", name, *ws.Memory)
 		}
 
 		cfg.Workspaces[name] = ws

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -316,8 +317,8 @@ func Validate(cfg *Config) error {
 		return err
 	}
 
-	if cfg.Defaults.CPU != nil && *cfg.Defaults.CPU <= 0 {
-		return fmt.Errorf("defaults: cpu must be greater than 0")
+	if cfg.Defaults.CPU != nil && (*cfg.Defaults.CPU <= 0 || math.IsNaN(*cfg.Defaults.CPU) || math.IsInf(*cfg.Defaults.CPU, 0)) {
+		return fmt.Errorf("defaults: cpu must be a finite number greater than 0")
 	}
 	if cfg.Defaults.Memory != nil && !validMemory.MatchString(*cfg.Defaults.Memory) {
 		return fmt.Errorf("defaults: invalid memory format %q: must be a positive integer optionally followed by k, m, or g (e.g. \"4g\", \"512m\")", *cfg.Defaults.Memory)
@@ -388,8 +389,8 @@ func Validate(cfg *Config) error {
 			return err
 		}
 
-		if ws.CPU != nil && *ws.CPU <= 0 {
-			return fmt.Errorf("workspace %q: cpu must be greater than 0", name)
+		if ws.CPU != nil && (*ws.CPU <= 0 || math.IsNaN(*ws.CPU) || math.IsInf(*ws.CPU, 0)) {
+			return fmt.Errorf("workspace %q: cpu must be a finite number greater than 0", name)
 		}
 		if ws.Memory != nil && !validMemory.MatchString(*ws.Memory) {
 			return fmt.Errorf("workspace %q: invalid memory format %q: must be a positive integer optionally followed by k, m, or g (e.g. \"4g\", \"512m\")", name, *ws.Memory)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2250,3 +2250,349 @@ func TestValidateErrorMessages(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigCPUMemoryParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		checkFn func(t *testing.T, cfg *Config)
+	}{
+		{
+			name: "defaults cpu and memory",
+			content: `
+[defaults]
+cpu = 1.5
+memory = "8g"
+
+[workspaces.x]
+paths = ["/data"]
+`,
+			checkFn: func(t *testing.T, cfg *Config) {
+				if cfg.Defaults.CPU == nil {
+					t.Fatal("expected Defaults.CPU to be non-nil")
+				}
+				if *cfg.Defaults.CPU != 1.5 {
+					t.Errorf("expected CPU 1.5, got %v", *cfg.Defaults.CPU)
+				}
+				if cfg.Defaults.Memory == nil {
+					t.Fatal("expected Defaults.Memory to be non-nil")
+				}
+				if *cfg.Defaults.Memory != "8g" {
+					t.Errorf("expected Memory \"8g\", got %q", *cfg.Defaults.Memory)
+				}
+			},
+		},
+		{
+			name: "workspace cpu and memory",
+			content: `
+[workspaces.test]
+paths = ["/data"]
+cpu = 4.0
+memory = "16g"
+`,
+			checkFn: func(t *testing.T, cfg *Config) {
+				ws := cfg.Workspaces["test"]
+				if ws.CPU == nil {
+					t.Fatal("expected Workspace.CPU to be non-nil")
+				}
+				if *ws.CPU != 4.0 {
+					t.Errorf("expected CPU 4.0, got %v", *ws.CPU)
+				}
+				if ws.Memory == nil {
+					t.Fatal("expected Workspace.Memory to be non-nil")
+				}
+				if *ws.Memory != "16g" {
+					t.Errorf("expected Memory \"16g\", got %q", *ws.Memory)
+				}
+			},
+		},
+		{
+			name: "no cpu and memory",
+			content: `
+[workspaces.x]
+paths = ["/data"]
+`,
+			checkFn: func(t *testing.T, cfg *Config) {
+				if cfg.Defaults.CPU != nil {
+					t.Errorf("expected Defaults.CPU to be nil, got %v", cfg.Defaults.CPU)
+				}
+				if cfg.Defaults.Memory != nil {
+					t.Errorf("expected Defaults.Memory to be nil, got %q", *cfg.Defaults.Memory)
+				}
+				ws := cfg.Workspaces["x"]
+				if ws.CPU != nil {
+					t.Errorf("expected Workspace.CPU to be nil, got %v", ws.CPU)
+				}
+				if ws.Memory != nil {
+					t.Errorf("expected Workspace.Memory to be nil, got %q", *ws.Memory)
+				}
+			},
+		},
+		{
+			name: "defaults and workspace independently",
+			content: `
+[defaults]
+cpu = 2.0
+memory = "4g"
+
+[workspaces.prod]
+paths = ["/data"]
+cpu = 8.0
+memory = "32g"
+`,
+			checkFn: func(t *testing.T, cfg *Config) {
+				if cfg.Defaults.CPU == nil || *cfg.Defaults.CPU != 2.0 {
+					t.Errorf("expected Defaults.CPU 2.0, got %v", cfg.Defaults.CPU)
+				}
+				if cfg.Defaults.Memory == nil || *cfg.Defaults.Memory != "4g" {
+					t.Errorf("expected Defaults.Memory \"4g\", got %v", cfg.Defaults.Memory)
+				}
+				ws := cfg.Workspaces["prod"]
+				if ws.CPU == nil || *ws.CPU != 8.0 {
+					t.Errorf("expected Workspace.CPU 8.0, got %v", ws.CPU)
+				}
+				if ws.Memory == nil || *ws.Memory != "32g" {
+					t.Errorf("expected Workspace.Memory \"32g\", got %v", ws.Memory)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			writeFile(t, path, tt.content)
+			cfg, err := LoadFrom(path)
+			if err != nil {
+				t.Fatalf("LoadFrom failed: %v", err)
+			}
+			tt.checkFn(t, cfg)
+		})
+	}
+}
+
+func TestConfigCPUMemoryValidation(t *testing.T) {
+	t.Parallel()
+
+	invalidTests := []struct {
+		name       string
+		cfg        *Config
+		errSubstrs []string
+	}{
+		{
+			name: "defaults cpu zero",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(0.0),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "cpu must be greater than 0"},
+		},
+		{
+			name: "defaults cpu negative",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(-1.0),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "cpu must be greater than 0"},
+		},
+		{
+			name: "workspace cpu zero",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"test": {
+						Paths: []string{"/data"},
+						CPU:   ptrFloat64(0.0),
+					},
+				},
+			},
+			errSubstrs: []string{"test", "cpu must be greater than 0"},
+		},
+		{
+			name: "workspace cpu negative",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"test": {
+						Paths: []string{"/data"},
+						CPU:   ptrFloat64(-1.0),
+					},
+				},
+			},
+			errSubstrs: []string{"test", "cpu must be greater than 0"},
+		},
+		{
+			name: "defaults memory zero",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("0g"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "invalid memory format"},
+		},
+		{
+			name: "defaults memory fractional",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("4.5g"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "invalid memory format"},
+		},
+		{
+			name: "defaults memory empty",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString(""),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "invalid memory format"},
+		},
+		{
+			name: "defaults memory invalid suffix",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("4gb"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "invalid memory format"},
+		},
+		{
+			name: "defaults memory negative",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("-1g"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "invalid memory format"},
+		},
+		{
+			name: "workspace memory invalid",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"test": {
+						Paths:  []string{"/data"},
+						Memory: ptrString("0m"),
+					},
+				},
+			},
+			errSubstrs: []string{"test", "invalid memory format"},
+		},
+	}
+
+	for _, tt := range invalidTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := Validate(tt.cfg)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			msg := err.Error()
+			for _, substr := range tt.errSubstrs {
+				if !strings.Contains(msg, substr) {
+					t.Errorf("error message %q missing expected substring %q", msg, substr)
+				}
+			}
+		})
+	}
+
+	validTests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{
+			name: "defaults memory lowercase m",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("512m"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+		},
+		{
+			name: "defaults memory uppercase G",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("4G"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+		},
+		{
+			name: "defaults memory bare integer",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("1024"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+		},
+		{
+			name: "defaults memory 4g",
+			cfg: &Config{
+				Defaults: Defaults{
+					Memory: ptrString("4g"),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+		},
+		{
+			name: "defaults cpu fractional",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(0.5),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+		},
+		{
+			name: "defaults cpu high",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(8.0),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+		},
+		{
+			name: "workspace memory 512m",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"test": {
+						Paths:  []string{"/data"},
+						Memory: ptrString("512m"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range validTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := Validate(tt.cfg)
+			if err != nil {
+				t.Errorf("expected nil error, got: %v", err)
+			}
+		})
+	}
+}
+
+func ptrFloat64(v float64) *float64 {
+	return &v
+}
+
+func ptrString(v string) *string {
+	return &v
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2391,7 +2392,7 @@ func TestConfigCPUMemoryValidation(t *testing.T) {
 				},
 				Workspaces: map[string]Workspace{},
 			},
-			errSubstrs: []string{"defaults", "cpu must be greater than 0"},
+			errSubstrs: []string{"defaults", "cpu must be a finite number greater than 0"},
 		},
 		{
 			name: "defaults cpu negative",
@@ -2401,7 +2402,7 @@ func TestConfigCPUMemoryValidation(t *testing.T) {
 				},
 				Workspaces: map[string]Workspace{},
 			},
-			errSubstrs: []string{"defaults", "cpu must be greater than 0"},
+			errSubstrs: []string{"defaults", "cpu must be a finite number greater than 0"},
 		},
 		{
 			name: "workspace cpu zero",
@@ -2413,7 +2414,7 @@ func TestConfigCPUMemoryValidation(t *testing.T) {
 					},
 				},
 			},
-			errSubstrs: []string{"test", "cpu must be greater than 0"},
+			errSubstrs: []string{"test", "cpu must be a finite number greater than 0"},
 		},
 		{
 			name: "workspace cpu negative",
@@ -2425,7 +2426,49 @@ func TestConfigCPUMemoryValidation(t *testing.T) {
 					},
 				},
 			},
-			errSubstrs: []string{"test", "cpu must be greater than 0"},
+			errSubstrs: []string{"test", "cpu must be a finite number greater than 0"},
+		},
+		{
+			name: "defaults cpu NaN",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(math.NaN()),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "cpu must be a finite number greater than 0"},
+		},
+		{
+			name: "defaults cpu positive infinity",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(math.Inf(1)),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "cpu must be a finite number greater than 0"},
+		},
+		{
+			name: "defaults cpu negative infinity",
+			cfg: &Config{
+				Defaults: Defaults{
+					CPU: ptrFloat64(math.Inf(-1)),
+				},
+				Workspaces: map[string]Workspace{},
+			},
+			errSubstrs: []string{"defaults", "cpu must be a finite number greater than 0"},
+		},
+		{
+			name: "workspace cpu NaN",
+			cfg: &Config{
+				Workspaces: map[string]Workspace{
+					"test": {
+						Paths: []string{"/data"},
+						CPU:   ptrFloat64(math.NaN()),
+					},
+				},
+			},
+			errSubstrs: []string{"test", "cpu must be a finite number greater than 0"},
 		},
 		{
 			name: "defaults memory zero",

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -53,10 +53,10 @@ services:
       - DAC_READ_SEARCH   # traverse restricted dirs during chown
     stdin_open: true
     tty: true
-    mem_limit: 4g
-    memswap_limit: 4g
+    mem_limit: {{.Memory}}
+    memswap_limit: {{.Memory}}
     mem_reservation: 512m
-    cpus: 2.0
+    cpus: {{printf "%.1f" .CPU}}
     pids_limit: 256
     networks:
       - dind
@@ -68,10 +68,10 @@ services:
 {{- end}}
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u \"opencode:$$OPENCODE_SERVER_PASSWORD\" http://localhost:4096/global/health || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 30s
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
   dind:
     image: docker:dind

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -53,10 +53,10 @@ services:
       - DAC_READ_SEARCH   # traverse restricted dirs during chown
     stdin_open: true
     tty: true
-    mem_limit: {{.Memory}}
-    memswap_limit: {{.Memory}}
+    mem_limit: "{{.Memory}}"
+    memswap_limit: "{{.Memory}}"
     mem_reservation: 512m
-    cpus: {{printf "%.1f" .CPU}}
+    cpus: {{printf "%g" .CPU}}
     pids_limit: 256
     networks:
       - dind

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -32,6 +32,8 @@ type Resolved struct {
 	Env             []string
 	SSHAuthSock     bool
 	GitConfig       bool
+	CPU             float64
+	Memory          string
 }
 
 func Resolve(cfg *config.Config, name string) (*Resolved, error) {
@@ -104,6 +106,8 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 		Env:             mergedEnv,
 		SSHAuthSock:     boolWithOverride(cfg.Defaults.SSHAuthSock, ws.SSHAuthSock),
 		GitConfig:       boolPtrWithDefault(cfg.Defaults.GitConfig, ws.GitConfig, true),
+		CPU:             floatWithDefault(cfg.Defaults.CPU, ws.CPU, 2.0),
+		Memory:          stringWithDefault(cfg.Defaults.Memory, ws.Memory, "4g"),
 	}, nil
 }
 
@@ -246,6 +250,26 @@ func boolWithOverride(defaultVal bool, override *bool) bool {
 }
 
 func boolPtrWithDefault(defaultVal *bool, override *bool, fallback bool) bool {
+	if override != nil {
+		return *override
+	}
+	if defaultVal != nil {
+		return *defaultVal
+	}
+	return fallback
+}
+
+func floatWithDefault(defaultVal *float64, override *float64, fallback float64) float64 {
+	if override != nil {
+		return *override
+	}
+	if defaultVal != nil {
+		return *defaultVal
+	}
+	return fallback
+}
+
+func stringWithDefault(defaultVal *string, override *string, fallback string) string {
 	if override != nil {
 		return *override
 	}

--- a/internal/workspace/workspace_internal_test.go
+++ b/internal/workspace/workspace_internal_test.go
@@ -2,6 +2,10 @@ package workspace
 
 import "testing"
 
+// Helper functions for creating pointers in tests.
+func f64(v float64) *float64 { return &v }
+func str(v string) *string   { return &v }
+
 func TestPathSegments(t *testing.T) {
 	t.Parallel()
 
@@ -21,6 +25,96 @@ func TestPathSegments(t *testing.T) {
 			t.Parallel()
 			if got := pathSegments(tt.path); got != tt.want {
 				t.Fatalf("pathSegments(%q) = %d, want %d", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFloatWithDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		defaultVal *float64
+		override   *float64
+		fallback   float64
+		want       float64
+	}{
+		{
+			name:       "override set returns override",
+			defaultVal: f64(1.0),
+			override:   f64(2.0),
+			fallback:   3.0,
+			want:       2.0,
+		},
+		{
+			name:       "override nil and defaultVal set returns defaultVal",
+			defaultVal: f64(1.0),
+			override:   nil,
+			fallback:   3.0,
+			want:       1.0,
+		},
+		{
+			name:       "both nil returns fallback",
+			defaultVal: nil,
+			override:   nil,
+			fallback:   3.0,
+			want:       3.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := floatWithDefault(tt.defaultVal, tt.override, tt.fallback)
+			if got != tt.want {
+				t.Fatalf("floatWithDefault(%v, %v, %v) = %v, want %v",
+					tt.defaultVal, tt.override, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringWithDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		defaultVal *string
+		override   *string
+		fallback   string
+		want       string
+	}{
+		{
+			name:       "override set returns override",
+			defaultVal: str("default"),
+			override:   str("override"),
+			fallback:   "fallback",
+			want:       "override",
+		},
+		{
+			name:       "override nil and defaultVal set returns defaultVal",
+			defaultVal: str("default"),
+			override:   nil,
+			fallback:   "fallback",
+			want:       "default",
+		},
+		{
+			name:       "both nil returns fallback",
+			defaultVal: nil,
+			override:   nil,
+			fallback:   "fallback",
+			want:       "fallback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := stringWithDefault(tt.defaultVal, tt.override, tt.fallback)
+			if got != tt.want {
+				t.Fatalf("stringWithDefault(%v, %v, %q) = %q, want %q",
+					tt.defaultVal, tt.override, tt.fallback, got, tt.want)
 			}
 		})
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1056,3 +1056,61 @@ func TestResolveFromCWDErrorMessages(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveCPUMemory(t *testing.T) {
+	t.Parallel()
+
+	f64 := func(v float64) *float64 { return &v }
+	str := func(v string) *string { return &v }
+
+	tests := []struct {
+		name       string
+		defCPU     *float64
+		defMemory  *string
+		wsCPU      *float64
+		wsMemory   *string
+		wantCPU    float64
+		wantMemory string
+	}{
+		{"workspace overrides defaults cpu", f64(1.0), nil, f64(4.0), nil, 4.0, "4g"},
+		{"workspace overrides defaults memory", nil, str("8g"), nil, str("16g"), 2.0, "16g"},
+		{"defaults used for cpu when workspace unset", f64(1.0), nil, nil, nil, 1.0, "4g"},
+		{"defaults used for memory when workspace unset", nil, str("8g"), nil, nil, 2.0, "8g"},
+		{"fallback cpu when both unset", nil, nil, nil, nil, 2.0, "4g"},
+		{"fallback memory when both unset", nil, nil, nil, nil, 2.0, "4g"},
+		{"workspace cpu without defaults", nil, nil, f64(0.5), nil, 0.5, "4g"},
+		{"workspace memory without defaults", nil, nil, nil, str("512m"), 2.0, "512m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				Defaults: config.Defaults{
+					CPU:    tt.defCPU,
+					Memory: tt.defMemory,
+				},
+				Workspaces: map[string]config.Workspace{
+					"test": {
+						Paths:  []string{"/data"},
+						CPU:    tt.wsCPU,
+						Memory: tt.wsMemory,
+					},
+				},
+			}
+
+			resolved, err := workspace.Resolve(cfg, "test")
+			if err != nil {
+				t.Fatalf("Resolve failed: %v", err)
+			}
+
+			if resolved.CPU != tt.wantCPU {
+				t.Errorf("CPU: got %v, want %v", resolved.CPU, tt.wantCPU)
+			}
+			if resolved.Memory != tt.wantMemory {
+				t.Errorf("Memory: got %q, want %q", resolved.Memory, tt.wantMemory)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add configurable `cpu` (float64) and `memory` (string) fields to `[defaults]` and `[workspaces.<name>]` config sections with three-level override chain (workspace → defaults → fallback: 2.0 CPU, 4g memory)
- Parameterize previously hardcoded resource limits in the compose template (`mem_limit`, `memswap_limit`, `cpus`) while keeping `pids_limit` (256) and `mem_reservation` (512m) fixed
- Relax health check timings from 10s/5s/3/30s to 30s/10s/5/60s to prevent false `unhealthy` status under heavy agent workloads

Closes #19