### PR TITLE
feat(config): add user-configurable mounts

### DIFF
--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -24,7 +24,7 @@ flowchart TB
     dind -.- net
 ```
 
-The **opencode container** is where the agent lives. It runs `opencode serve` as UID 1000 (a non-root user named `agent`), exposes a port to the host for attaching a terminal, and has your workspace paths mounted read-write. Your OpenCode configuration is mounted read-only so the agent inherits your API keys and settings without being able to modify them on the host.
+The **opencode container** is where the agent lives. It runs `opencode serve` as UID 1000 (a non-root user named `agent`), exposes a port to the host for attaching a terminal, and has your workspace paths mounted read-write. Host directories are mounted into the container via configurable bind mounts — by default, your OpenCode configuration (read-only), session transcripts, and agent tooling directories. See [How-to: Configure mounts](../how-to/workspace-configuration.md#configure-mounts) for customization.
 
 The opencode container runs with configurable resource limits. The `cpu` (default 2 cores) and `memory` (default 4 GB) settings control how much of the host's resources the container can consume, and are configurable per workspace via the TOML config. Other resource limits — `pids_limit` (256) and `mem_reservation` (512 MB) — are fixed and not configurable. Resource limit changes take effect on the next `jailoc up` invocation; running containers are not affected until restarted.
 
@@ -41,8 +41,7 @@ The opencode container mounts several things at startup:
 | Mount | Direction | Purpose |
 |-------|-----------|---------|
 | Workspace paths | read-write | The directories the agent is working in |
-| `~/.config/opencode` | read-only | Your API keys, model config, provider settings |
-| `~/.claude/transcripts` | read-write | Claude Code session transcripts, persisted back to the host |
+| Configurable mounts | per-mount | Host directories mounted into the container, controlled by the `mounts` config field. Defaults include OpenCode configuration (ro), session transcripts (rw), and agent tooling (ro). See [Configuration Reference](../reference/configuration.md#mounts) for the full list and merge rules. |
 | `/etc/jailoc` | read-only | jailoc's own runtime config, including allowed hosts |
 | SSH agent socket | read-write | Host SSH agent forwarded into the container (when `ssh_auth_sock = true`). Also mounts `~/.ssh/known_hosts` read-only for host key verification. |
 | `~/.gitconfig` | read-only | Host Git configuration (when `git_config = true`, the default) |

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -193,6 +193,48 @@ env_file = ["~/.config/jailoc/shared.env"]
 
 ---
 
+## Configure mounts
+
+jailoc mounts several host directories into the container by default (OpenCode config, session transcripts, agent tooling). To add extra mounts or override the defaults, use the `mounts` field.
+
+Add a host directory to the container:
+
+```toml
+[workspaces.my-project]
+paths = ["/home/you/projects/my-project"]
+mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode"]
+```
+
+Each entry follows `host:container[:mode]` format. The mode is `ro` (read-only) or `rw` (read-write, the default).
+
+To remove a default mount, set an empty host source for that container path:
+
+```toml
+[workspaces.my-project]
+paths = ["/home/you/projects/my-project"]
+mounts = [":/home/agent/.opencode:ro"]
+```
+
+This removes the `~/.opencode` mount for the `my-project` workspace.
+
+Mounts set in `[defaults]` apply to all workspaces. Per-workspace `mounts` override defaults for the same container path:
+
+```toml
+[defaults]
+mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode:ro"]
+
+[workspaces.my-project]
+paths = ["/home/you/projects/my-project"]
+mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode:rw"]
+```
+
+!!! note
+    Host paths under `~/.ssh`, `~/.gnupg`, and `~/.aws` are forbidden in mounts. Container paths are validated against the same forbidden prefixes as `paths`.
+
+See [Configuration reference](../reference/configuration.md) for the full mount format, merge semantics, and validation rules.
+
+---
+
 ## Forward SSH agent and Git config
 
 To let the agent clone private repositories or push over SSH, enable SSH agent forwarding. Git configuration is mounted by default.

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -229,7 +229,7 @@ mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode:rw"]
 ```
 
 !!! note
-    Dangerous host paths are forbidden in mounts: `/`, `/boot`, `/dev`, `/etc`, `/proc`, `/sys`, `/run`, `/var`, `~/.ssh`, `~/.gnupg`, `~/.aws`. Container destinations under `/home/agent/...` are allowed; other system directories (`/usr`, `/etc`, `/var`, etc.) are forbidden.
+    Dangerous host paths are forbidden in mounts: `/`, `/boot`, `/dev`, `/etc`, `/private`, `/proc`, `/sys`, `/run`, `/var`, `~/.ssh`, `~/.gnupg`, `~/.aws`. Container destinations under `/home/agent/...` are allowed; other system directories (`/usr`, `/etc`, `/var`, etc.) are forbidden.
 
 See [Configuration reference](../reference/configuration.md) for the full mount format, merge semantics, and validation rules.
 

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -229,7 +229,7 @@ mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode:rw"]
 ```
 
 !!! note
-    Host paths under `~/.ssh`, `~/.gnupg`, and `~/.aws` are forbidden in mounts. Container paths are validated against the same forbidden prefixes as `paths`.
+    Dangerous host paths are forbidden in mounts: `/`, `/boot`, `/dev`, `/etc`, `/proc`, `/sys`, `/run`, `/var`, `~/.ssh`, `~/.gnupg`, `~/.aws`. Container destinations under `/home/agent/...` are allowed; other system directories (`/usr`, `/etc`, `/var`, etc.) are forbidden.
 
 See [Configuration reference](../reference/configuration.md) for the full mount format, merge semantics, and validation rules.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -145,6 +145,7 @@ The following host paths are forbidden:
 | `/boot` |
 | `/dev` |
 | `/etc` |
+| `/private` |
 | `/proc` |
 | `/sys` |
 | `/run` |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -74,7 +74,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `paths` | string[] | (required) | Directories bind-mounted into the container at their original absolute paths. The first path becomes the container's working directory. Supports `~` expansion. |
-| `mounts` | string[] | `[]` | Bind mounts for this workspace. Format: `host:container[:mode]` — mode is `ro` or `rw` (default `rw`). An empty host source (e.g. `":/home/agent/.opencode:ro"`) removes a default mount matching the container path. Container paths are validated against the same forbidden prefixes as `paths`. |
+| `mounts` | string[] | `[]` | Bind mounts for this workspace. Format: `host:container[:mode]` — mode is `ro` or `rw` (default `rw`). An empty host source (e.g. `":/home/agent/.opencode:ro"`) removes a default mount matching the container path. Container destinations under `/home/agent/...` are allowed (unlike `paths`); see [mounts validation](#mounts) for the full list of forbidden container prefixes. |
 | `allowed_hosts` | string[] | `[]` | Hostnames resolved at container start and added as iptables `ACCEPT` rules before the private-range `DROP` rules. |
 | `allowed_networks` | string[] | `[]` | CIDR ranges explicitly allowed through the container firewall. |
 | `image` | string | (none) | Pre-built Docker image to use directly for this workspace, bypassing all build steps. Compose pulls the image natively at startup. Cannot be combined with `dockerfile` or `build_context`. |
@@ -134,20 +134,26 @@ Each entry is validated against a list of forbidden path prefixes. Paths startin
 Each entry uses the format `host:container[:mode]`.
 
 - `host`: a local path (absolute or starting with `~`). An empty string signals removal of a default mount matching the container path.
-- `container`: must be an absolute path after `~` expansion. Validated against the same forbidden prefixes as `paths` (see table above).
+- `container`: must be an absolute path after `~` expansion. Validated against a separate set of forbidden prefixes: `/usr`, `/etc`, `/var`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/opt`, `/root`, `/proc`, `/sys`, `/dev`, `/run`, `/tmp`, `/certs`. Unlike `paths`, destinations under `/home/agent/...` are allowed.
 - `mode`: `ro` or `rw`. Defaults to `rw` when omitted.
 
 The following host paths are forbidden:
 
 | Forbidden host path |
 |---|
+| `/` |
+| `/boot` |
+| `/dev` |
+| `/etc` |
+| `/proc` |
+| `/sys` |
+| `/run` |
+| `/var` |
 | `~/.ssh` |
 | `~/.gnupg` |
 | `~/.aws` |
-| `/etc/shadow` |
-| `/etc/passwd` |
 
-Any host path starting with these prefixes is rejected.
+Any host path equal to or starting with these prefixes is rejected.
 
 ### `allowed_networks`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -39,6 +39,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 | `image` | string | (none) | Pre-built Docker image used as the base for workspace Dockerfile builds, or pulled directly when no workspace `dockerfile` is set. |
 | `env` | string[] | `[]` | Environment variables applied to all workspaces. Each entry must be in `KEY=VALUE` format. Workspace `env` entries take precedence over defaults with the same key. |
 | `env_file` | string[] | `[]` | Paths to `.env` files loaded for all workspaces. Each file must exist at config load time. Paths must be absolute (`/...`) or start with `~`. Parsed before workspace-level `env_file` entries. |
+| `mounts` | string[] | `[]` | Additional bind mounts for all workspaces. Each entry follows `host:container[:mode]` format where mode is `ro` or `rw` (default `rw`). An empty host source removes a default mount matching the container path. Merged with per-workspace `mounts` — see Merge Semantics below. Supports `~` expansion on both host and container sides. |
 | `allowed_hosts` | string[] | `[]` | Hostnames allowed through the firewall for all workspaces. Merged with per-workspace `allowed_hosts`. |
 | `allowed_networks` | string[] | `[]` | CIDR ranges allowed through the firewall for all workspaces. Merged with per-workspace `allowed_networks`. |
 | `ssh_auth_sock` | bool | `false` | Mount the host SSH agent socket into the container. Auto-detects the socket: Docker Desktop/OrbStack magic path first, then `$SSH_AUTH_SOCK`. Also mounts `~/.ssh/known_hosts` read-only when enabled. |
@@ -53,6 +54,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 image = "myregistry.example.com/myteam/opencode-base:v1.2.3"
 env = ["GOPRIVATE=*.example.com", "NPM_REGISTRY=https://npm.example.com"]
 env_file = ["~/.config/jailoc/shared.env"]
+mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode"]
 allowed_hosts = ["internal-registry.example.com"]
 allowed_networks = ["10.0.0.0/8"]
 ssh_auth_sock = true
@@ -72,6 +74,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `paths` | string[] | (required) | Directories bind-mounted into the container at their original absolute paths. The first path becomes the container's working directory. Supports `~` expansion. |
+| `mounts` | string[] | `[]` | Bind mounts for this workspace. Format: `host:container[:mode]` — mode is `ro` or `rw` (default `rw`). An empty host source (e.g. `":/home/agent/.opencode:ro"`) removes a default mount matching the container path. Container paths are validated against the same forbidden prefixes as `paths`. |
 | `allowed_hosts` | string[] | `[]` | Hostnames resolved at container start and added as iptables `ACCEPT` rules before the private-range `DROP` rules. |
 | `allowed_networks` | string[] | `[]` | CIDR ranges explicitly allowed through the container firewall. |
 | `image` | string | (none) | Pre-built Docker image to use directly for this workspace, bypassing all build steps. Compose pulls the image natively at startup. Cannot be combined with `dockerfile` or `build_context`. |
@@ -95,6 +98,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 paths = ["~/projects/my-project", "~/shared/libs"]
 allowed_hosts = ["api.example.com", "pypi.org"]
 allowed_networks = ["10.0.0.0/8"]
+mounts = ["~/.local/share/opencode:/home/agent/.local/share/opencode"]
 build_context = "~/projects/my-project/docker"
 mode = "remote"
 dockerfile = "~/projects/my-project/overlay.Dockerfile"
@@ -124,6 +128,26 @@ Each entry is validated against a list of forbidden path prefixes. Paths startin
 | `/lib64` |
 
 `~` is expanded to `$HOME` before validation. HTTP(S) URLs in `dockerfile` fields are not subject to `~` expansion; local paths starting with `~` are expanded.
+
+### `mounts`
+
+Each entry uses the format `host:container[:mode]`.
+
+- `host`: a local path (absolute or starting with `~`). An empty string signals removal of a default mount matching the container path.
+- `container`: must be an absolute path after `~` expansion. Validated against the same forbidden prefixes as `paths` (see table above).
+- `mode`: `ro` or `rw`. Defaults to `rw` when omitted.
+
+The following host paths are forbidden:
+
+| Forbidden host path |
+|---|
+| `~/.ssh` |
+| `~/.gnupg` |
+| `~/.aws` |
+| `/etc/shadow` |
+| `/etc/passwd` |
+
+Any host path starting with these prefixes is rejected.
 
 ### `allowed_networks`
 
@@ -190,6 +214,15 @@ Environment variables from multiple sources are merged in this order (later entr
 4. Workspace `env` — per-workspace inline values (highest priority)
 
 `allowed_hosts` and `allowed_networks` use union deduplication: the global list is merged with the workspace list, with duplicates removed, preserving order.
+
+`mounts` follows a three-layer merge keyed by container path. Default mounts (built into jailoc) are applied first, then `[defaults].mounts`, then per-workspace `mounts`. For each container path, the last layer to set it wins. An entry with an empty host source removes the mount for that container path. The built-in default mounts are:
+
+| Container path | Host source | Mode |
+|---|---|---|
+| `/home/agent/.config/opencode` | `~/.config/opencode` | `ro` |
+| `/home/agent/.opencode` | `~/.opencode` | `ro` |
+| `/home/agent/.claude/transcripts` | `~/.claude/transcripts` | `rw` |
+| `/home/agent/.agents` | `~/.agents` | `ro` |
 
 `ssh_auth_sock` and `git_config` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config` falls back to `true` when neither the workspace nor defaults set it.
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -126,6 +126,8 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		AllowedNetworks:  ws2.AllowedNetworks,
 		OpenCodePassword: password,
 		Env:              ws2.Env,
+		UseDataVolume:    !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.local/share/opencode"),
+		UseCacheVolume:   !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.cache"),
 	}
 
 	if err := config.WriteAllowedFiles(ws2.Name, cfg); err != nil {

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -121,6 +121,7 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		Port:             ws2.Port,
 		Image:            "jailoc-base:embedded",
 		Paths:            ws2.Paths,
+		Mounts:           ws2.Mounts,
 		AllowedHosts:     ws2.AllowedHosts,
 		AllowedNetworks:  ws2.AllowedNetworks,
 		OpenCodePassword: password,

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -115,7 +115,6 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return fmt.Errorf("re-resolve workspace for restart: %w", err)
 	}
 
-	password := os.Getenv("OPENCODE_SERVER_PASSWORD")
 	params := compose.ComposeParams{
 		WorkspaceName:    ws2.Name,
 		Port:             ws2.Port,
@@ -124,8 +123,13 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		Mounts:           ws2.Mounts,
 		AllowedHosts:     ws2.AllowedHosts,
 		AllowedNetworks:  ws2.AllowedNetworks,
-		OpenCodePassword: password,
+		OpenCodePassword: os.Getenv("OPENCODE_SERVER_PASSWORD"),
 		Env:              ws2.Env,
+		SSHAuthSock:      resolveSSHAuthSock(ws2.SSHAuthSock),
+		SSHKnownHosts:    resolveSSHKnownHosts(ws2.SSHAuthSock),
+		GitConfig:        resolveGitConfig(ws2.GitConfig),
+		CPU:              ws2.CPU,
+		Memory:           ws2.Memory,
 		UseDataVolume:    !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.local/share/opencode"),
 		UseCacheVolume:   !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.cache"),
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -98,6 +98,7 @@ func runUp(ctx context.Context, args []string) error {
 		Port:             ws.Port,
 		Image:            finalImage,
 		Paths:            ws.Paths,
+		Mounts:           ws.Mounts,
 		AllowedHosts:     ws.AllowedHosts,
 		AllowedNetworks:  ws.AllowedNetworks,
 		OpenCodePassword: os.Getenv("OPENCODE_SERVER_PASSWORD"),

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -108,6 +108,8 @@ func runUp(ctx context.Context, args []string) error {
 		GitConfig:        resolveGitConfig(ws.GitConfig),
 		CPU:              ws.CPU,
 		Memory:           ws.Memory,
+		UseDataVolume:    !compose.MountsContainTarget(ws.Mounts, "/home/agent/.local/share/opencode"),
+		UseCacheVolume:   !compose.MountsContainTarget(ws.Mounts, "/home/agent/.cache"),
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Generating compose configuration...\n")

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -15,6 +15,7 @@ type ComposeParams struct {
 	Port             int
 	Image            string
 	Paths            []string
+	Mounts           []string
 	AllowedHosts     []string
 	AllowedNetworks  []string
 	OpenCodePassword string

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -25,6 +25,8 @@ type ComposeParams struct {
 	GitConfig        string // host gitconfig path to mount, empty = disabled
 	CPU              float64
 	Memory           string
+	UseDataVolume    bool
+	UseCacheVolume   bool
 }
 
 func GenerateCompose(params ComposeParams) ([]byte, error) {
@@ -54,4 +56,14 @@ func WriteComposeFile(params ComposeParams, destPath string) error {
 	}
 
 	return nil
+}
+
+func MountsContainTarget(mounts []string, containerPath string) bool {
+	for _, m := range mounts {
+		parts := strings.SplitN(m, ":", 3)
+		if len(parts) >= 2 && parts[1] == containerPath {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -19,6 +19,8 @@ func TestGenerateComposeSinglePath(t *testing.T) {
 		Env:              nil,
 		CPU:              2.0,
 		Memory:           "4g",
+		UseDataVolume:    true,
+		UseCacheVolume:   true,
 	}
 
 	out, err := GenerateCompose(params)
@@ -100,13 +102,15 @@ func TestGenerateComposeVolumeNamesIncludeWorkspaceName(t *testing.T) {
 	t.Parallel()
 
 	params := ComposeParams{
-		WorkspaceName: "delta",
-		Port:          4444,
-		Image:         "ghcr.io/seznam/jailoc:main",
-		Paths:         []string{"/tmp/repo"},
-		Env:           nil,
-		CPU:           2.0,
-		Memory:        "4g",
+		WorkspaceName:  "delta",
+		Port:           4444,
+		Image:          "ghcr.io/seznam/jailoc:main",
+		Paths:          []string{"/tmp/repo"},
+		Env:            nil,
+		CPU:            2.0,
+		Memory:         "4g",
+		UseDataVolume:  true,
+		UseCacheVolume: true,
 	}
 
 	out, err := GenerateCompose(params)
@@ -557,6 +561,170 @@ func TestComposeHealthCheckTimings(t *testing.T) {
 	}
 	if strings.Contains(string(rendered), "retries: 3\n") {
 		t.Error("old health check retries: 3 still present")
+	}
+}
+
+func TestGenerateComposeNamedVolumeOverriddenByMount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("data volume overridden", func(t *testing.T) {
+		t.Parallel()
+		params := ComposeParams{
+			WorkspaceName: "vol-override",
+			Port:          4900,
+			Image:         "ghcr.io/seznam/jailoc:test",
+			Paths:         []string{"/tmp/work"},
+			Mounts: []string{
+				"/host/data:/home/agent/.local/share/opencode:rw",
+			},
+			UseDataVolume:  false,
+			UseCacheVolume: true,
+			CPU:            2.0,
+			Memory:         "4g",
+		}
+
+		out, err := GenerateCompose(params)
+		if err != nil {
+			t.Fatalf("GenerateCompose returned error: %v", err)
+		}
+
+		rendered := string(out)
+		assertContains(t, rendered, "/host/data:/home/agent/.local/share/opencode:rw")
+		if strings.Contains(rendered, "opencode-data-vol-override:/home/agent/.local/share/opencode") {
+			t.Fatalf("expected named data volume to be absent when overridden by mount, got:\n%s", rendered)
+		}
+		// Cache volume should still be present
+		assertContains(t, rendered, "opencode-cache-vol-override:/home/agent/.cache")
+	})
+
+	t.Run("cache volume overridden", func(t *testing.T) {
+		t.Parallel()
+		params := ComposeParams{
+			WorkspaceName: "cache-override",
+			Port:          4901,
+			Image:         "ghcr.io/seznam/jailoc:test",
+			Paths:         []string{"/tmp/work"},
+			Mounts: []string{
+				"/host/cache:/home/agent/.cache:rw",
+			},
+			UseDataVolume:  true,
+			UseCacheVolume: false,
+			CPU:            2.0,
+			Memory:         "4g",
+		}
+
+		out, err := GenerateCompose(params)
+		if err != nil {
+			t.Fatalf("GenerateCompose returned error: %v", err)
+		}
+
+		rendered := string(out)
+		assertContains(t, rendered, "/host/cache:/home/agent/.cache:rw")
+		if strings.Contains(rendered, "opencode-cache-cache-override:/home/agent/.cache") {
+			t.Fatalf("expected named cache volume to be absent when overridden by mount, got:\n%s", rendered)
+		}
+		// Data volume should still be present
+		assertContains(t, rendered, "opencode-data-cache-override:/home/agent/.local/share/opencode")
+	})
+
+	t.Run("both volumes overridden", func(t *testing.T) {
+		t.Parallel()
+		params := ComposeParams{
+			WorkspaceName: "both-override",
+			Port:          4902,
+			Image:         "ghcr.io/seznam/jailoc:test",
+			Paths:         []string{"/tmp/work"},
+			Mounts: []string{
+				"/host/data:/home/agent/.local/share/opencode:rw",
+				"/host/cache:/home/agent/.cache:rw",
+			},
+			UseDataVolume:  false,
+			UseCacheVolume: false,
+			CPU:            2.0,
+			Memory:         "4g",
+		}
+
+		out, err := GenerateCompose(params)
+		if err != nil {
+			t.Fatalf("GenerateCompose returned error: %v", err)
+		}
+
+		rendered := string(out)
+		if strings.Contains(rendered, "opencode-data-both-override") {
+			t.Fatalf("expected no named data volume, got:\n%s", rendered)
+		}
+		if strings.Contains(rendered, "opencode-cache-both-override") {
+			t.Fatalf("expected no named cache volume, got:\n%s", rendered)
+		}
+	})
+
+	t.Run("default volumes present", func(t *testing.T) {
+		t.Parallel()
+		params := ComposeParams{
+			WorkspaceName:  "default-vols",
+			Port:           4903,
+			Image:          "ghcr.io/seznam/jailoc:test",
+			Paths:          []string{"/tmp/work"},
+			UseDataVolume:  true,
+			UseCacheVolume: true,
+			CPU:            2.0,
+			Memory:         "4g",
+		}
+
+		out, err := GenerateCompose(params)
+		if err != nil {
+			t.Fatalf("GenerateCompose returned error: %v", err)
+		}
+
+		rendered := string(out)
+		assertContains(t, rendered, "opencode-data-default-vols:/home/agent/.local/share/opencode")
+		assertContains(t, rendered, "opencode-cache-default-vols:/home/agent/.cache")
+	})
+}
+
+func TestMountsContainTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		mounts        []string
+		containerPath string
+		want          bool
+	}{
+		{
+			name:          "match",
+			mounts:        []string{"/host/data:/home/agent/.local/share/opencode:rw"},
+			containerPath: "/home/agent/.local/share/opencode",
+			want:          true,
+		},
+		{
+			name:          "no match",
+			mounts:        []string{"/host/data:/home/agent/.config/opencode:ro"},
+			containerPath: "/home/agent/.local/share/opencode",
+			want:          false,
+		},
+		{
+			name:          "empty mounts",
+			mounts:        nil,
+			containerPath: "/home/agent/.cache",
+			want:          false,
+		},
+		{
+			name:          "partial path no match",
+			mounts:        []string{"/host:/home/agent/.cache/subdir:rw"},
+			containerPath: "/home/agent/.cache",
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MountsContainTarget(tt.mounts, tt.containerPath)
+			if got != tt.want {
+				t.Errorf("MountsContainTarget(%v, %q) = %v, want %v", tt.mounts, tt.containerPath, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -559,3 +559,43 @@ func TestComposeHealthCheckTimings(t *testing.T) {
 		t.Error("old health check retries: 3 still present")
 	}
 }
+
+func TestGenerateComposeMountsFromParams(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "mounts-test",
+		Port:          4800,
+		Image:         "ghcr.io/seznam/jailoc:test",
+		Paths:         []string{"/tmp/work"},
+		Mounts: []string{
+			"/home/user/.config/opencode:/home/agent/.config/opencode:ro",
+			"/home/user/.agents:/home/agent/.agents:ro",
+		},
+		OpenCodePassword: "secret",
+		CPU:              2.0,
+		Memory:           "4g",
+	}
+
+	out, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose returned error: %v", err)
+	}
+
+	rendered := string(out)
+	assertContains(t, rendered, "/home/user/.config/opencode:/home/agent/.config/opencode:ro")
+	assertContains(t, rendered, "/home/user/.agents:/home/agent/.agents:ro")
+
+	if strings.Contains(rendered, "${HOME}/.config/opencode:/home/agent/.config/opencode:ro") {
+		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "${HOME}/.opencode:/home/agent/.opencode:ro") {
+		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "${HOME}/.claude/transcripts:/home/agent/.claude/transcripts") {
+		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "${HOME}/.agents:/home/agent/.agents:ro") {
+		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
+	}
+}

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -767,3 +767,41 @@ func TestGenerateComposeMountsFromParams(t *testing.T) {
 		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
 	}
 }
+
+func TestGenerateComposeMountOrderAfterNamedVolumes(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "order-test",
+		Port:          4810,
+		Image:         "ghcr.io/seznam/jailoc:test",
+		Paths:         []string{"/tmp/work"},
+		Mounts: []string{
+			"/host/custom:/home/agent/custom:rw",
+		},
+		UseDataVolume:  true,
+		UseCacheVolume: true,
+		CPU:            2.0,
+		Memory:         "4g",
+	}
+
+	out, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose returned error: %v", err)
+	}
+
+	rendered := string(out)
+
+	dataVolIdx := strings.Index(rendered, "opencode-data-order-test:/home/agent/.local/share/opencode")
+	mountIdx := strings.Index(rendered, "/host/custom:/home/agent/custom:rw")
+
+	if dataVolIdx < 0 {
+		t.Fatalf("expected named data volume in output, got:\n%s", rendered)
+	}
+	if mountIdx < 0 {
+		t.Fatalf("expected user mount in output, got:\n%s", rendered)
+	}
+	if mountIdx < dataVolIdx {
+		t.Fatalf("expected user mounts to appear after named volumes so they take precedence;\nnamed volume at index %d, user mount at index %d", dataVolIdx, mountIdx)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -866,7 +866,7 @@ func expandPaths(ws *Workspace) error {
 		}
 
 		m.Host = expandedHost
-		m.Container = expandedContainer
+		m.Container = filepath.Clean(expandedContainer)
 		ws.Mounts[i] = formatMount(m)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,11 +115,17 @@ var forbiddenMountContainerPrefixes = []string{
 }
 
 var forbiddenMountHostPaths = []string{
+	"/",
+	"/boot",
+	"/dev",
+	"/etc",
+	"/proc",
+	"/sys",
+	"/run",
+	"/var",
 	"~/.ssh",
 	"~/.gnupg",
 	"~/.aws",
-	"/etc/shadow",
-	"/etc/passwd",
 }
 
 var DefaultMounts = []string{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ var forbiddenMountPrefixes = []string{
 // Unlike forbiddenMountPrefixes (used for workspace paths), this does NOT include /home/agent,
 // because mounts intentionally target /home/agent/... subpaths (e.g. the default OC mounts).
 var forbiddenMountContainerPrefixes = []string{
+	"/",
 	"/usr",
 	"/etc",
 	"/var",
@@ -509,7 +510,7 @@ func Validate(cfg *Config) error {
 		}
 
 		m.Host = expandedHost
-		m.Container = expandedContainer
+		m.Container = filepath.Clean(expandedContainer)
 		if !strings.HasPrefix(m.Container, "/") {
 			return fmt.Errorf("defaults: mount container path %q must be absolute (start with /)", m.Container)
 		}
@@ -584,13 +585,14 @@ func Validate(cfg *Config) error {
 			if err != nil {
 				return fmt.Errorf("workspace %q: expand mount container path %q: %w", name, m.Container, err)
 			}
-			if !strings.HasPrefix(expandedContainer, "/") {
-				return fmt.Errorf("workspace %q: mount container path %q must be absolute (start with /)", name, expandedContainer)
+			cleanedContainer := filepath.Clean(expandedContainer)
+			if !strings.HasPrefix(cleanedContainer, "/") {
+				return fmt.Errorf("workspace %q: mount container path %q must be absolute (start with /)", name, cleanedContainer)
 			}
 
 			for _, prefix := range forbiddenMountContainerPrefixes {
-				if expandedContainer == prefix || strings.HasPrefix(expandedContainer, prefix+"/") {
-					return fmt.Errorf("workspace %q: mount container path %q is not allowed (conflicts with container-internal directory %q)", name, expandedContainer, prefix)
+				if cleanedContainer == prefix || strings.HasPrefix(cleanedContainer, prefix+"/") {
+					return fmt.Errorf("workspace %q: mount container path %q is not allowed (conflicts with container-internal directory %q)", name, cleanedContainer, prefix)
 				}
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ const (
 # image = ""
 # env = ["KEY=VALUE"]
 # env_file = ["/path/to/.env"]
+# mounts = ["~/.config/opencode:/home/agent/.config/opencode:ro"]
 # allowed_hosts = ["example.com"]
 # allowed_networks = ["10.0.0.0/8"]
 # ssh_auth_sock = false
@@ -44,6 +45,7 @@ paths = []
 # allowed_networks = []
 # env = ["KEY=VALUE"]
 # env_file = ["/path/to/.env"]
+# mounts = ["~/.config/opencode:/home/agent/.config/opencode:ro"]
 # build_context = ""
 # dockerfile = ""
 # ssh_auth_sock = false
@@ -91,6 +93,27 @@ var forbiddenMountPrefixes = []string{
 	"/certs",
 }
 
+var forbiddenMountHostPaths = []string{
+	"~/.ssh",
+	"~/.gnupg",
+	"~/.aws",
+	"/etc/shadow",
+	"/etc/passwd",
+}
+
+var DefaultMounts = []string{
+	"~/.config/opencode:/home/agent/.config/opencode:ro",
+	"~/.opencode:/home/agent/.opencode:ro",
+	"~/.claude/transcripts:/home/agent/.claude/transcripts:rw",
+	"~/.agents:/home/agent/.agents:ro",
+}
+
+type Mount struct {
+	Host      string
+	Container string
+	Mode      string
+}
+
 type Config struct {
 	Mode       string               `toml:"mode"`
 	Base       BaseConfig           `toml:"base"`
@@ -105,6 +128,7 @@ type BaseConfig struct {
 type Defaults struct {
 	Env             []string `toml:"env"`
 	EnvFile         []string `toml:"env_file"`
+	Mounts          []string `toml:"mounts"`
 	AllowedHosts    []string `toml:"allowed_hosts"`
 	AllowedNetworks []string `toml:"allowed_networks"`
 	Image           string   `toml:"image"`
@@ -116,6 +140,7 @@ type Defaults struct {
 
 type Workspace struct {
 	Paths           []string `toml:"paths"`
+	Mounts          []string `toml:"mounts"`
 	AllowedHosts    []string `toml:"allowed_hosts"`
 	AllowedNetworks []string `toml:"allowed_networks"`
 	Env             []string `toml:"env"`
@@ -276,6 +301,116 @@ func validateEnvFiles(paths []string, context string) error {
 	return nil
 }
 
+func ParseMount(spec string) (Mount, error) {
+	parts := strings.Split(spec, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return Mount{}, fmt.Errorf("invalid mount spec %q: expected host:container[:mode]", spec)
+	}
+
+	host := parts[0]
+	container := parts[1]
+	mode := "rw"
+	if len(parts) == 3 {
+		mode = parts[2]
+	}
+
+	if mode != "ro" && mode != "rw" {
+		return Mount{}, fmt.Errorf("invalid mount spec %q: mode must be ro or rw", spec)
+	}
+
+	expandedContainer, err := ExpandPath(container)
+	if err != nil {
+		return Mount{}, fmt.Errorf("expand mount container path %q: %w", container, err)
+	}
+	if !strings.HasPrefix(expandedContainer, "/") {
+		return Mount{}, fmt.Errorf("invalid mount spec %q: container path %q must be absolute (start with /)", spec, container)
+	}
+
+	return Mount{Host: host, Container: container, Mode: mode}, nil
+}
+
+func validateMountHostPath(host string, context string) error {
+	if host == "" {
+		return nil
+	}
+
+	expandedHost, err := ExpandPath(host)
+	if err != nil {
+		return fmt.Errorf("%s: expand mount host path %q: %w", context, host, err)
+	}
+
+	for _, forbidden := range forbiddenMountHostPaths {
+		expandedForbidden, err := ExpandPath(forbidden)
+		if err != nil {
+			return fmt.Errorf("%s: expand forbidden mount host path %q: %w", context, forbidden, err)
+		}
+		if strings.HasPrefix(expandedHost, expandedForbidden) {
+			return fmt.Errorf("%s: mount host path %q is forbidden", context, expandedHost)
+		}
+	}
+
+	return nil
+}
+
+func formatMount(m Mount) string {
+	return fmt.Sprintf("%s:%s:%s", m.Host, m.Container, m.Mode)
+}
+
+func MergeMounts(layers ...[]string) []string {
+	if len(layers) == 0 {
+		return nil
+	}
+
+	orderedContainers := make([]string, 0)
+	seenContainers := make(map[string]bool)
+	byContainer := make(map[string]Mount)
+
+	for _, layer := range layers {
+		for _, spec := range layer {
+			m, err := ParseMount(spec)
+			if err != nil {
+				continue
+			}
+
+			expandedHost := m.Host
+			if m.Host != "" {
+				expanded, err := ExpandPath(m.Host)
+				if err != nil {
+					continue
+				}
+				expandedHost = expanded
+			}
+
+			if !seenContainers[m.Container] {
+				seenContainers[m.Container] = true
+				orderedContainers = append(orderedContainers, m.Container)
+			}
+
+			if m.Host == "" {
+				delete(byContainer, m.Container)
+				continue
+			}
+
+			byContainer[m.Container] = Mount{
+				Host:      expandedHost,
+				Container: m.Container,
+				Mode:      m.Mode,
+			}
+		}
+	}
+
+	merged := make([]string, 0, len(byContainer))
+	for _, container := range orderedContainers {
+		m, ok := byContainer[container]
+		if !ok {
+			continue
+		}
+		merged = append(merged, formatMount(m))
+	}
+
+	return merged
+}
+
 func Validate(cfg *Config) error {
 	if cfg == nil {
 		return fmt.Errorf("config is nil")
@@ -315,6 +450,34 @@ func Validate(cfg *Config) error {
 
 	if err := validateEnvFiles(cfg.Defaults.EnvFile, "defaults"); err != nil {
 		return err
+	}
+
+	for i, spec := range cfg.Defaults.Mounts {
+		m, err := ParseMount(spec)
+		if err != nil {
+			return fmt.Errorf("defaults: %w", err)
+		}
+
+		expandedHost, err := ExpandPath(m.Host)
+		if err != nil {
+			return fmt.Errorf("defaults: expand mount host path %q: %w", m.Host, err)
+		}
+		expandedContainer, err := ExpandPath(m.Container)
+		if err != nil {
+			return fmt.Errorf("defaults: expand mount container path %q: %w", m.Container, err)
+		}
+
+		m.Host = expandedHost
+		m.Container = expandedContainer
+		if !strings.HasPrefix(m.Container, "/") {
+			return fmt.Errorf("defaults: mount container path %q must be absolute (start with /)", m.Container)
+		}
+
+		if err := validateMountHostPath(m.Host, "defaults"); err != nil {
+			return err
+		}
+
+		cfg.Defaults.Mounts[i] = formatMount(m)
 	}
 
 	if cfg.Defaults.CPU != nil && (*cfg.Defaults.CPU <= 0 || math.IsNaN(*cfg.Defaults.CPU) || math.IsInf(*cfg.Defaults.CPU, 0)) {
@@ -357,6 +520,31 @@ func Validate(cfg *Config) error {
 				_, _ = color.New(color.FgYellow).Fprintf(os.Stderr, "warning: path %q is configured in multiple workspaces: %q and %q\n", p, owner, name)
 			} else {
 				pathOwners[p] = name
+			}
+		}
+
+		for _, spec := range ws.Mounts {
+			m, err := ParseMount(spec)
+			if err != nil {
+				return fmt.Errorf("workspace %q: %w", name, err)
+			}
+
+			if err := validateMountHostPath(m.Host, fmt.Sprintf("workspace %q", name)); err != nil {
+				return err
+			}
+
+			expandedContainer, err := ExpandPath(m.Container)
+			if err != nil {
+				return fmt.Errorf("workspace %q: expand mount container path %q: %w", name, m.Container, err)
+			}
+			if !strings.HasPrefix(expandedContainer, "/") {
+				return fmt.Errorf("workspace %q: mount container path %q must be absolute (start with /)", name, expandedContainer)
+			}
+
+			for _, prefix := range forbiddenMountPrefixes {
+				if expandedContainer == prefix || strings.HasPrefix(expandedContainer, prefix+"/") {
+					return fmt.Errorf("workspace %q: mount container path %q conflicts with container-internal directory %q", name, expandedContainer, prefix)
+				}
 			}
 		}
 
@@ -611,6 +799,26 @@ func expandPaths(ws *Workspace) error {
 			return fmt.Errorf("expand env_file path %q: %w", p, err)
 		}
 		ws.EnvFile[i] = expanded
+	}
+
+	for i, spec := range ws.Mounts {
+		m, err := ParseMount(spec)
+		if err != nil {
+			return fmt.Errorf("parse mount %q: %w", spec, err)
+		}
+
+		expandedHost, err := ExpandPath(m.Host)
+		if err != nil {
+			return fmt.Errorf("expand mount host path %q: %w", m.Host, err)
+		}
+		expandedContainer, err := ExpandPath(m.Container)
+		if err != nil {
+			return fmt.Errorf("expand mount container path %q: %w", m.Container, err)
+		}
+
+		m.Host = expandedHost
+		m.Container = expandedContainer
+		ws.Mounts[i] = formatMount(m)
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,6 +93,27 @@ var forbiddenMountPrefixes = []string{
 	"/certs",
 }
 
+// forbiddenMountContainerPrefixes lists container-side mount destinations that must not be overridden.
+// Unlike forbiddenMountPrefixes (used for workspace paths), this does NOT include /home/agent,
+// because mounts intentionally target /home/agent/... subpaths (e.g. the default OC mounts).
+var forbiddenMountContainerPrefixes = []string{
+	"/usr",
+	"/etc",
+	"/var",
+	"/bin",
+	"/sbin",
+	"/lib",
+	"/lib64",
+	"/opt",
+	"/root",
+	"/proc",
+	"/sys",
+	"/dev",
+	"/run",
+	"/tmp",
+	"/certs",
+}
+
 var forbiddenMountHostPaths = []string{
 	"~/.ssh",
 	"~/.gnupg",
@@ -318,6 +339,16 @@ func ParseMount(spec string) (Mount, error) {
 		return Mount{}, fmt.Errorf("invalid mount spec %q: mode must be ro or rw", spec)
 	}
 
+	if host != "" {
+		expandedHost, err := ExpandPath(host)
+		if err != nil {
+			return Mount{}, fmt.Errorf("expand mount host path %q: %w", host, err)
+		}
+		if !strings.HasPrefix(expandedHost, "/") {
+			return Mount{}, fmt.Errorf("invalid mount spec %q: host path %q must be absolute (start with / or ~)", spec, host)
+		}
+	}
+
 	expandedContainer, err := ExpandPath(container)
 	if err != nil {
 		return Mount{}, fmt.Errorf("expand mount container path %q: %w", container, err)
@@ -338,14 +369,18 @@ func validateMountHostPath(host string, context string) error {
 	if err != nil {
 		return fmt.Errorf("%s: expand mount host path %q: %w", context, host, err)
 	}
+	cleanHost := filepath.Clean(expandedHost)
 
 	for _, forbidden := range forbiddenMountHostPaths {
 		expandedForbidden, err := ExpandPath(forbidden)
 		if err != nil {
 			return fmt.Errorf("%s: expand forbidden mount host path %q: %w", context, forbidden, err)
 		}
-		if strings.HasPrefix(expandedHost, expandedForbidden) {
-			return fmt.Errorf("%s: mount host path %q is forbidden", context, expandedHost)
+
+		cleanForbidden := filepath.Clean(expandedForbidden)
+		forbiddenPrefix := cleanForbidden + string(os.PathSeparator)
+		if cleanHost == cleanForbidden || strings.HasPrefix(cleanHost, forbiddenPrefix) {
+			return fmt.Errorf("%s: mount host path %q is forbidden", context, cleanHost)
 		}
 	}
 
@@ -356,9 +391,9 @@ func formatMount(m Mount) string {
 	return fmt.Sprintf("%s:%s:%s", m.Host, m.Container, m.Mode)
 }
 
-func MergeMounts(layers ...[]string) []string {
+func MergeMounts(layers ...[]string) ([]string, error) {
 	if len(layers) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	orderedContainers := make([]string, 0)
@@ -369,14 +404,14 @@ func MergeMounts(layers ...[]string) []string {
 		for _, spec := range layer {
 			m, err := ParseMount(spec)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("parse mount spec %q: %w", spec, err)
 			}
 
 			expandedHost := m.Host
 			if m.Host != "" {
 				expanded, err := ExpandPath(m.Host)
 				if err != nil {
-					continue
+					return nil, fmt.Errorf("expand mount host path %q: %w", m.Host, err)
 				}
 				expandedHost = expanded
 			}
@@ -408,7 +443,7 @@ func MergeMounts(layers ...[]string) []string {
 		merged = append(merged, formatMount(m))
 	}
 
-	return merged
+	return merged, nil
 }
 
 func Validate(cfg *Config) error {
@@ -471,6 +506,12 @@ func Validate(cfg *Config) error {
 		m.Container = expandedContainer
 		if !strings.HasPrefix(m.Container, "/") {
 			return fmt.Errorf("defaults: mount container path %q must be absolute (start with /)", m.Container)
+		}
+
+		for _, prefix := range forbiddenMountContainerPrefixes {
+			if m.Container == prefix || strings.HasPrefix(m.Container, prefix+"/") {
+				return fmt.Errorf("defaults: mount container path %q is not allowed (conflicts with container-internal directory %q)", m.Container, prefix)
+			}
 		}
 
 		if err := validateMountHostPath(m.Host, "defaults"); err != nil {
@@ -541,9 +582,9 @@ func Validate(cfg *Config) error {
 				return fmt.Errorf("workspace %q: mount container path %q must be absolute (start with /)", name, expandedContainer)
 			}
 
-			for _, prefix := range forbiddenMountPrefixes {
+			for _, prefix := range forbiddenMountContainerPrefixes {
 				if expandedContainer == prefix || strings.HasPrefix(expandedContainer, prefix+"/") {
-					return fmt.Errorf("workspace %q: mount container path %q conflicts with container-internal directory %q", name, expandedContainer, prefix)
+					return fmt.Errorf("workspace %q: mount container path %q is not allowed (conflicts with container-internal directory %q)", name, expandedContainer, prefix)
 				}
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,7 @@ var forbiddenMountHostPaths = []string{
 	"/boot",
 	"/dev",
 	"/etc",
+	"/private",
 	"/proc",
 	"/sys",
 	"/run",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2377,6 +2377,21 @@ func TestValidateMountsHostPathValidation(t *testing.T) {
 			spec:      "/etc/shadow:/container:ro",
 			wantError: true,
 		},
+		{
+			name:      "/private/etc bypasses /etc via symlink on macOS",
+			spec:      "/private/etc:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/private/var bypasses /var via symlink on macOS",
+			spec:      "/private/var:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/private/var subpath is rejected",
+			spec:      "/private/var/run:/container:ro",
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1630,6 +1630,52 @@ func TestExpandPathsTildeEnvFile(t *testing.T) {
 	})
 }
 
+func TestExpandPathsNormalizesContainerPath(t *testing.T) {
+	home := "/data/home_test_" + strings.ReplaceAll(t.Name(), "/", "_")
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name      string
+		spec      string
+		wantMount string
+	}{
+		{
+			name:      "trailing slash removed",
+			spec:      "/host/dir:/container/path/:ro",
+			wantMount: "/host/dir:/container/path:ro",
+		},
+		{
+			name:      "dot segment cleaned",
+			spec:      "/host/dir:/container/./path:rw",
+			wantMount: "/host/dir:/container/path:rw",
+		},
+		{
+			name:      "double slash cleaned",
+			spec:      "/host/dir:/container//path:ro",
+			wantMount: "/host/dir:/container/path:ro",
+		},
+		{
+			name:      "tilde and traversal cleaned",
+			spec:      "~/data:/home/agent/../agent/data:rw",
+			wantMount: home + "/data:/home/agent/data:rw",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &Workspace{
+				Paths:  []string{"/data"},
+				Mounts: []string{tt.spec},
+			}
+			if err := expandPaths(ws); err != nil {
+				t.Fatalf("expandPaths failed: %v", err)
+			}
+			if ws.Mounts[0] != tt.wantMount {
+				t.Fatalf("got %q, want %q", ws.Mounts[0], tt.wantMount)
+			}
+		})
+	}
+}
+
 func TestValidateImageAndDockerfileMutualExclusivity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,20 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
+// safeHome creates a temporary HOME directory outside forbidden mount host paths
+// (e.g. /var on macOS, where t.TempDir() resolves). Mount validation tests need
+// this because ~ expansion resolves to HOME, and /var is a forbidden host prefix.
+func safeHome(t *testing.T) string {
+	t.Helper()
+	home, err := os.MkdirTemp("/tmp", "jailoc-test-home-*")
+	if err != nil {
+		t.Fatalf("create safe home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("HOME", home)
+	return home
+}
+
 func TestLoadFullConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")
@@ -2245,8 +2259,7 @@ func TestMergeMountsInvalidSpec(t *testing.T) {
 }
 
 func TestValidateMountsHostPathValidation(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	safeHome(t)
 
 	tests := []struct {
 		name      string
@@ -2271,6 +2284,51 @@ func TestValidateMountsHostPathValidation(t *testing.T) {
 		{
 			name:      "forbidden subpath is rejected",
 			spec:      "~/.ssh/keys:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "root filesystem is rejected",
+			spec:      "/:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/boot is rejected",
+			spec:      "/boot:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/dev is rejected",
+			spec:      "/dev:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/proc is rejected",
+			spec:      "/proc:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/sys is rejected",
+			spec:      "/sys:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/run is rejected",
+			spec:      "/run:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/var is rejected",
+			spec:      "/var:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/etc is rejected",
+			spec:      "/etc:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "/etc subpath is rejected",
+			spec:      "/etc/shadow:/container:ro",
 			wantError: true,
 		},
 	}
@@ -2305,8 +2363,7 @@ func TestValidateMountsHostPathValidation(t *testing.T) {
 }
 
 func TestValidateMountsAcceptsSafe(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	safeHome(t)
 
 	cfg := &Config{
 		Defaults: Defaults{
@@ -2326,8 +2383,7 @@ func TestValidateMountsAcceptsSafe(t *testing.T) {
 }
 
 func TestValidateMountsInDefaults(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := safeHome(t)
 
 	cfg := &Config{
 		Defaults: Defaults{
@@ -2348,8 +2404,7 @@ func TestValidateMountsInDefaults(t *testing.T) {
 }
 
 func TestValidateMountsInDefaultsRejectsForbiddenContainerPath(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	safeHome(t)
 
 	cfg := &Config{
 		Defaults: Defaults{
@@ -2370,8 +2425,7 @@ func TestValidateMountsInDefaultsRejectsForbiddenContainerPath(t *testing.T) {
 }
 
 func TestValidateMountsInWorkspace(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	safeHome(t)
 
 	t.Run("valid workspace mounts", func(t *testing.T) {
 		cfg := &Config{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2060,6 +2060,280 @@ image = "alpine:latest"
 	}
 }
 
+func TestParseMountValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		spec      string
+		host      string
+		container string
+		mode      string
+	}{
+		{
+			name:      "host and container with implicit rw",
+			spec:      "/host/path:/container/path",
+			host:      "/host/path",
+			container: "/container/path",
+			mode:      "rw",
+		},
+		{
+			name:      "host container ro",
+			spec:      "/host:/container:ro",
+			host:      "/host",
+			container: "/container",
+			mode:      "ro",
+		},
+		{
+			name:      "removal implicit rw",
+			spec:      ":/container/path",
+			host:      "",
+			container: "/container/path",
+			mode:      "rw",
+		},
+		{
+			name:      "removal explicit ro",
+			spec:      ":/container:ro",
+			host:      "",
+			container: "/container",
+			mode:      "ro",
+		},
+		{
+			name:      "tilde host",
+			spec:      "~/.config/oc:/home/agent/.config/oc:ro",
+			host:      "~/.config/oc",
+			container: "/home/agent/.config/oc",
+			mode:      "ro",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseMount(tt.spec)
+			if err != nil {
+				t.Fatalf("ParseMount(%q) failed: %v", tt.spec, err)
+			}
+
+			if got.Host != tt.host || got.Container != tt.container || got.Mode != tt.mode {
+				t.Fatalf("ParseMount(%q) = %#v, want host=%q container=%q mode=%q", tt.spec, got, tt.host, tt.container, tt.mode)
+			}
+		})
+	}
+}
+
+func TestParseMountInvalid(t *testing.T) {
+	t.Parallel()
+
+	invalidSpecs := []string{
+		"",
+		"/only-one-part",
+		"/a:/b:invalid",
+		"/a:/b:ro:extra",
+		"/host:relative/path",
+	}
+
+	for _, spec := range invalidSpecs {
+		t.Run(spec, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := ParseMount(spec); err == nil {
+				t.Fatalf("expected ParseMount(%q) to fail", spec)
+			}
+		})
+	}
+}
+
+func TestMergeMounts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name     string
+		layers   [][]string
+		expected []string
+	}{
+		{
+			name: "default mounts only",
+			layers: [][]string{
+				DefaultMounts,
+			},
+			expected: []string{
+				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+			},
+		},
+		{
+			name: "override default mount mode",
+			layers: [][]string{
+				DefaultMounts,
+				{"~/cfg:/home/agent/.config/opencode:rw"},
+			},
+			expected: []string{
+				filepath.Join(home, "cfg") + ":/home/agent/.config/opencode:rw",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+			},
+		},
+		{
+			name: "remove default mount",
+			layers: [][]string{
+				DefaultMounts,
+				{":/home/agent/.opencode"},
+			},
+			expected: []string{
+				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+			},
+		},
+		{
+			name: "add new mount",
+			layers: [][]string{
+				DefaultMounts,
+				{"~/my-data:/workspace/data:rw"},
+			},
+			expected: []string{
+				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+				filepath.Join(home, "my-data") + ":/workspace/data:rw",
+			},
+		},
+		{
+			name: "multiple layers overrides and removals",
+			layers: [][]string{
+				DefaultMounts,
+				{"~/cfg:/home/agent/.config/opencode:rw", "~/x:/x:rw"},
+				{":/home/agent/.agents", "~/y:/x:ro"},
+			},
+			expected: []string{
+				filepath.Join(home, "cfg") + ":/home/agent/.config/opencode:rw",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+				filepath.Join(home, "y") + ":/x:ro",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeMounts(tt.layers...)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Fatalf("MergeMounts() = %#v, want %#v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateMountsForbiddenHostPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Workspaces: map[string]Workspace{
+			"default": {
+				Paths:  []string{"/data/workspace"},
+				Mounts: []string{"~/.ssh:/safe/mount:ro"},
+			},
+		},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected forbidden mount host path to be rejected")
+	}
+	if !strings.Contains(err.Error(), "forbidden") {
+		t.Fatalf("expected forbidden error, got: %v", err)
+	}
+}
+
+func TestValidateMountsAcceptsSafe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &Config{
+		Defaults: Defaults{
+			Mounts: []string{"~/safe:/workspace/safe:rw"},
+		},
+		Workspaces: map[string]Workspace{
+			"default": {
+				Paths:  []string{"/data/workspace"},
+				Mounts: []string{"~/other:/workspace/other:ro"},
+			},
+		},
+	}
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("expected safe mounts to pass validation, got: %v", err)
+	}
+}
+
+func TestValidateMountsInDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &Config{
+		Defaults: Defaults{
+			Mounts: []string{"~/cfg:/workspace/cfg:ro"},
+		},
+		Workspaces: map[string]Workspace{
+			"default": {Paths: []string{"/data/workspace"}},
+		},
+	}
+
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("expected defaults.mounts validation to pass, got: %v", err)
+	}
+
+	if got := cfg.Defaults.Mounts[0]; !strings.HasPrefix(got, home+"/") {
+		t.Fatalf("expected defaults.mounts host to be expanded, got: %q", got)
+	}
+}
+
+func TestValidateMountsInWorkspace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	t.Run("valid workspace mounts", func(t *testing.T) {
+		cfg := &Config{
+			Workspaces: map[string]Workspace{
+				"default": {
+					Paths:  []string{"/data/workspace"},
+					Mounts: []string{"~/safe:/workspace/safe:rw"},
+				},
+			},
+		}
+
+		if err := Validate(cfg); err != nil {
+			t.Fatalf("expected workspace.mounts validation to pass, got: %v", err)
+		}
+	})
+
+	t.Run("forbidden container prefix", func(t *testing.T) {
+		cfg := &Config{
+			Workspaces: map[string]Workspace{
+				"default": {
+					Paths:  []string{"/data/workspace"},
+					Mounts: []string{"~/safe:/etc/inside:ro"},
+				},
+			},
+		}
+
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("expected forbidden workspace mount container path to fail")
+		}
+		if !strings.Contains(err.Error(), "conflicts with container-internal directory") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestValidateErrorMessages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2424,6 +2424,48 @@ func TestValidateMountsInDefaultsRejectsForbiddenContainerPath(t *testing.T) {
 	}
 }
 
+func TestValidateMountsInDefaultsRejectsContainerTraversal(t *testing.T) {
+	safeHome(t)
+
+	cfg := &Config{
+		Defaults: Defaults{
+			Mounts: []string{"~/safe:/home/agent/../../etc:ro"},
+		},
+		Workspaces: map[string]Workspace{
+			"default": {Paths: []string{"/data/workspace"}},
+		},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected defaults container path traversal to fail")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected not allowed error, got: %v", err)
+	}
+}
+
+func TestValidateMountsInDefaultsRejectsRootContainerPath(t *testing.T) {
+	safeHome(t)
+
+	cfg := &Config{
+		Defaults: Defaults{
+			Mounts: []string{"~/safe:/:rw"},
+		},
+		Workspaces: map[string]Workspace{
+			"default": {Paths: []string{"/data/workspace"}},
+		},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected defaults root container path to fail")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected not allowed error, got: %v", err)
+	}
+}
+
 func TestValidateMountsInWorkspace(t *testing.T) {
 	safeHome(t)
 
@@ -2473,6 +2515,44 @@ func TestValidateMountsInWorkspace(t *testing.T) {
 
 		if err := Validate(cfg); err != nil {
 			t.Fatalf("expected /home/agent mount override to be allowed, got: %v", err)
+		}
+	})
+
+	t.Run("container path traversal blocked", func(t *testing.T) {
+		cfg := &Config{
+			Workspaces: map[string]Workspace{
+				"default": {
+					Paths:  []string{"/data/workspace"},
+					Mounts: []string{"~/safe:/home/agent/../../etc:ro"},
+				},
+			},
+		}
+
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("expected container path traversal to be blocked")
+		}
+		if !strings.Contains(err.Error(), "not allowed") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("root container path blocked", func(t *testing.T) {
+		cfg := &Config{
+			Workspaces: map[string]Workspace{
+				"default": {
+					Paths:  []string{"/data/workspace"},
+					Mounts: []string{"~/safe:/:rw"},
+				},
+			},
+		}
+
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("expected root container path to be blocked")
+		}
+		if !strings.Contains(err.Error(), "not allowed") {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2132,6 +2132,7 @@ func TestParseMountInvalid(t *testing.T) {
 		"/a:/b:invalid",
 		"/a:/b:ro:extra",
 		"/host:relative/path",
+		"relative-host:/container:rw",
 	}
 
 	for _, spec := range invalidSpecs {
@@ -2223,7 +2224,10 @@ func TestMergeMounts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := MergeMounts(tt.layers...)
+			got, err := MergeMounts(tt.layers...)
+			if err != nil {
+				t.Fatalf("MergeMounts() returned error: %v", err)
+			}
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Fatalf("MergeMounts() = %#v, want %#v", got, tt.expected)
 			}
@@ -2231,24 +2235,72 @@ func TestMergeMounts(t *testing.T) {
 	}
 }
 
-func TestValidateMountsForbiddenHostPath(t *testing.T) {
+func TestMergeMountsInvalidSpec(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Config{
-		Workspaces: map[string]Workspace{
-			"default": {
-				Paths:  []string{"/data/workspace"},
-				Mounts: []string{"~/.ssh:/safe/mount:ro"},
-			},
+	_, err := MergeMounts([]string{"relative-host:/container:rw"})
+	if err == nil {
+		t.Fatal("expected MergeMounts to fail for invalid mount spec")
+	}
+}
+
+func TestValidateMountsHostPathValidation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name      string
+		spec      string
+		wantError bool
+	}{
+		{
+			name:      "sibling path does not match forbidden prefix",
+			spec:      "~/.ssh-other:/container:ro",
+			wantError: false,
+		},
+		{
+			name:      "traversal into forbidden path is rejected",
+			spec:      "~/.config/../.ssh:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "exact forbidden path is rejected",
+			spec:      "~/.ssh:/container:ro",
+			wantError: true,
+		},
+		{
+			name:      "forbidden subpath is rejected",
+			spec:      "~/.ssh/keys:/container:ro",
+			wantError: true,
 		},
 	}
 
-	err := Validate(cfg)
-	if err == nil {
-		t.Fatal("expected forbidden mount host path to be rejected")
-	}
-	if !strings.Contains(err.Error(), "forbidden") {
-		t.Fatalf("expected forbidden error, got: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Workspaces: map[string]Workspace{
+					"default": {
+						Paths:  []string{"/data/workspace"},
+						Mounts: []string{tt.spec},
+					},
+				},
+			}
+
+			err := Validate(cfg)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected validation to fail for mount %q", tt.spec)
+				}
+				if !strings.Contains(err.Error(), "forbidden") {
+					t.Fatalf("expected forbidden error, got: %v", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected validation to pass for mount %q, got: %v", tt.spec, err)
+			}
+		})
 	}
 }
 
@@ -2295,6 +2347,28 @@ func TestValidateMountsInDefaults(t *testing.T) {
 	}
 }
 
+func TestValidateMountsInDefaultsRejectsForbiddenContainerPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &Config{
+		Defaults: Defaults{
+			Mounts: []string{"~/safe:/etc/inside:ro"},
+		},
+		Workspaces: map[string]Workspace{
+			"default": {Paths: []string{"/data/workspace"}},
+		},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected defaults mount container path to fail")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected not allowed error, got: %v", err)
+	}
+}
+
 func TestValidateMountsInWorkspace(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -2328,8 +2402,23 @@ func TestValidateMountsInWorkspace(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected forbidden workspace mount container path to fail")
 		}
-		if !strings.Contains(err.Error(), "conflicts with container-internal directory") {
+		if !strings.Contains(err.Error(), "not allowed") {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("home agent config path is allowed", func(t *testing.T) {
+		cfg := &Config{
+			Workspaces: map[string]Workspace{
+				"default": {
+					Paths:  []string{"/data/workspace"},
+					Mounts: []string{"~/safe:/home/agent/.config/opencode:rw"},
+				},
+			},
+		}
+
+		if err := Validate(cfg); err != nil {
+			t.Fatalf("expected /home/agent mount override to be allowed, got: %v", err)
 		}
 	})
 }

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -10,17 +10,17 @@ services:
 {{- range .Paths}}
       - {{.}}:{{.}}
 {{- end}}
-{{- range .Mounts}}
-      - {{.}}
-{{- end}}
-      - ${HOME}/.config/jailoc/workspaces/{{.WorkspaceName}}:/etc/jailoc:ro
-      - ${HOME}/.cache/jailoc/{{.WorkspaceName}}/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
 {{- if .UseDataVolume}}
       - opencode-data-{{.WorkspaceName}}:/home/agent/.local/share/opencode
 {{- end}}
 {{- if .UseCacheVolume}}
       - opencode-cache-{{.WorkspaceName}}:/home/agent/.cache
 {{- end}}
+{{- range .Mounts}}
+      - {{.}}
+{{- end}}
+      - ${HOME}/.config/jailoc/workspaces/{{.WorkspaceName}}:/etc/jailoc:ro
+      - ${HOME}/.cache/jailoc/{{.WorkspaceName}}/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - dind-certs-client:/certs/client:ro
 {{- if .SSHAuthSock}}
       - {{.SSHAuthSock}}:/run/ssh-agent.sock

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -15,8 +15,12 @@ services:
 {{- end}}
       - ${HOME}/.config/jailoc/workspaces/{{.WorkspaceName}}:/etc/jailoc:ro
       - ${HOME}/.cache/jailoc/{{.WorkspaceName}}/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
+{{- if .UseDataVolume}}
       - opencode-data-{{.WorkspaceName}}:/home/agent/.local/share/opencode
+{{- end}}
+{{- if .UseCacheVolume}}
       - opencode-cache-{{.WorkspaceName}}:/home/agent/.cache
+{{- end}}
       - dind-certs-client:/certs/client:ro
 {{- if .SSHAuthSock}}
       - {{.SSHAuthSock}}:/run/ssh-agent.sock
@@ -102,8 +106,12 @@ services:
       - "2376"
 
 volumes:
+{{- if .UseDataVolume}}
   opencode-data-{{.WorkspaceName}}:
+{{- end}}
+{{- if .UseCacheVolume}}
   opencode-cache-{{.WorkspaceName}}:
+{{- end}}
   dind-certs-ca:
   dind-certs-client:
   dind-data:

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -10,10 +10,9 @@ services:
 {{- range .Paths}}
       - {{.}}:{{.}}
 {{- end}}
-      - ${HOME}/.config/opencode:/home/agent/.config/opencode:ro
-      - ${HOME}/.opencode:/home/agent/.opencode:ro
-      - ${HOME}/.claude/transcripts:/home/agent/.claude/transcripts
-      - ${HOME}/.agents:/home/agent/.agents:ro
+{{- range .Mounts}}
+      - {{.}}
+{{- end}}
       - ${HOME}/.config/jailoc/workspaces/{{.WorkspaceName}}:/etc/jailoc:ro
       - ${HOME}/.cache/jailoc/{{.WorkspaceName}}/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - opencode-data-{{.WorkspaceName}}:/home/agent/.local/share/opencode

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -95,7 +95,10 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 	mergedEnv = append(mergedEnv, ws.Env...)
 	mergedEnv = dedupEnvByKeyLastWins(mergedEnv)
 
-	mergedMounts := config.MergeMounts(config.DefaultMounts, cfg.Defaults.Mounts, ws.Mounts)
+	mergedMounts, err := config.MergeMounts(config.DefaultMounts, cfg.Defaults.Mounts, ws.Mounts)
+	if err != nil {
+		return nil, fmt.Errorf("merge mounts for workspace %s: %w", name, err)
+	}
 
 	return &Resolved{
 		Name:            name,

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -23,6 +23,7 @@ const BasePort = 4096
 type Resolved struct {
 	Name            string
 	Paths           []string
+	Mounts          []string
 	Port            int
 	AllowedHosts    []string
 	AllowedNetworks []string
@@ -94,9 +95,12 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 	mergedEnv = append(mergedEnv, ws.Env...)
 	mergedEnv = dedupEnvByKeyLastWins(mergedEnv)
 
+	mergedMounts := config.MergeMounts(config.DefaultMounts, cfg.Defaults.Mounts, ws.Mounts)
+
 	return &Resolved{
 		Name:            name,
 		Paths:           paths,
+		Mounts:          mergedMounts,
 		Port:            PortForWorkspace(cfg, name),
 		AllowedHosts:    ws.AllowedHosts,
 		AllowedNetworks: ws.AllowedNetworks,

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1201,3 +1201,24 @@ func TestResolveMountsRemoval(t *testing.T) {
 		t.Fatalf("mounts mismatch: got %#v want %#v", resolved.Mounts, want)
 	}
 }
+
+func TestResolveMountsMergeError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Defaults: config.Defaults{
+			Mounts: []string{"relative-host:/container:rw"},
+		},
+		Workspaces: map[string]config.Workspace{
+			"default": {Paths: []string{"/tmp"}},
+		},
+	}
+
+	_, err := workspace.Resolve(cfg, "default")
+	if err == nil {
+		t.Fatal("expected Resolve to fail when mount merge fails")
+	}
+	if !strings.Contains(err.Error(), "merge mounts for workspace default") {
+		t.Fatalf("unexpected error context: %v", err)
+	}
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1112,5 +1113,91 @@ func TestResolveCPUMemory(t *testing.T) {
 				t.Errorf("Memory: got %q, want %q", resolved.Memory, tt.wantMemory)
 			}
 		})
+	}
+}
+
+func TestResolveMountsDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &config.Config{
+		Workspaces: map[string]config.Workspace{
+			"default": {Paths: []string{"/tmp"}},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "default")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+		filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+		filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+		filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+	}
+
+	if !reflect.DeepEqual(resolved.Mounts, want) {
+		t.Fatalf("mounts mismatch: got %#v want %#v", resolved.Mounts, want)
+	}
+}
+
+func TestResolveMountsOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &config.Config{
+		Defaults: config.Defaults{
+			Mounts: []string{"~/custom-opencode:/home/agent/.config/opencode:rw"},
+		},
+		Workspaces: map[string]config.Workspace{
+			"default": {Paths: []string{"/tmp"}},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "default")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(home, "custom-opencode") + ":/home/agent/.config/opencode:rw",
+		filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+		filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+		filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+	}
+
+	if !reflect.DeepEqual(resolved.Mounts, want) {
+		t.Fatalf("mounts mismatch: got %#v want %#v", resolved.Mounts, want)
+	}
+}
+
+func TestResolveMountsRemoval(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &config.Config{
+		Workspaces: map[string]config.Workspace{
+			"default": {
+				Paths:  []string{"/tmp"},
+				Mounts: []string{":/home/agent/.opencode"},
+			},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "default")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+		filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
+		filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
+	}
+
+	if !reflect.DeepEqual(resolved.Mounts, want) {
+		t.Fatalf("mounts mismatch: got %#v want %#v", resolved.Mounts, want)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #18.

- Add `mounts` field to `[defaults]` and `[workspaces.<name>]` for controlling which host directories are bind-mounted into the container
- Format: `host:container[:mode]` — mode is `ro`/`rw` (default `rw`), empty host source removes a default mount
- Three-layer merge: built-in defaults → `[defaults].mounts` → workspace `mounts`, keyed by container path
- Replace hardcoded OC mounts in compose template with dynamic `{{range .Mounts}}` block
- Forbid security-sensitive host paths (`~/.ssh`, `~/.gnupg`, `~/.aws`, `/etc/shadow`, `/etc/passwd`)
- Validate container paths against existing `forbiddenMountPrefixes`
- 11 new tests across config, workspace, and compose packages
- Update reference, how-to, and explanation docs