### PR TITLE
fix(entrypoint): avoid recursive chown on bind-mounted transcripts dir

### DIFF
--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -70,7 +70,8 @@ iptables -A OUTPUT -d 192.168.0.0/16 -j DROP
 iptables -A OUTPUT -d 169.254.0.0/16 -j DROP
 iptables -A OUTPUT -d 100.64.0.0/10 -j DROP
 
-chown -R 1000:1000 /home/agent/.local /home/agent/.cache /home/agent/.claude
+chown -R 1000:1000 /home/agent/.local /home/agent/.cache
+chown 1000:1000 /home/agent/.claude
 
 if [ -S /run/ssh-agent.sock ]; then
   chown 1000:1000 /run/ssh-agent.sock 2>/dev/null || true


### PR DESCRIPTION
## Summary

- `chown -R` on `/home/agent/.claude` recurses into the bind-mounted `~/.claude/transcripts` directory — Colima's file sharing driver (sshfs/9p) returns EPERM on chown for bind-mounted host paths, crashing the container due to `set -e`
- Split into recursive chown for `.local`/`.cache` (named volumes, support chown) and non-recursive chown for `.claude` (only the overlay parent dir needs ownership fix, the bind-mounted transcripts subdir is accessed via mount driver)
- OrbStack was unaffected because its VirtioFS layer silently succeeds on chown for bind mounts

Fixes container startup crash on Colima: `chown: changing ownership of '/home/agent/.claude/transcripts': Permission denied`