### PR TITLE
fix(entrypoint): suppress chown errors on read-only bind mounts

### DIFF
--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -78,7 +78,7 @@ if [ -S /run/ssh-agent.sock ]; then
 fi
 
 if [ -d /home/agent/.ssh ]; then
-  chown 1000:1000 /home/agent/.ssh
+  chown 1000:1000 /home/agent/.ssh 2>/dev/null || true
 fi
 
 exec setpriv --reuid=1000 --regid=1000 --init-groups --inh-caps=-all --no-new-privs -- env HOME=/home/agent "$@"

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -70,8 +70,8 @@ iptables -A OUTPUT -d 192.168.0.0/16 -j DROP
 iptables -A OUTPUT -d 169.254.0.0/16 -j DROP
 iptables -A OUTPUT -d 100.64.0.0/10 -j DROP
 
-chown -R 1000:1000 /home/agent/.local /home/agent/.cache
-chown 1000:1000 /home/agent/.claude
+chown -R 1000:1000 /home/agent/.local /home/agent/.cache 2>/dev/null || true
+chown 1000:1000 /home/agent/.claude 2>/dev/null || true
 
 if [ -S /run/ssh-agent.sock ]; then
   chown 1000:1000 /run/ssh-agent.sock 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Read-only bind mounts inside chowned trees cause `chown -R` to fail
  with EPERM, killing the entrypoint under `set -e`
- Example: mounting `auth.json:ro` into `.local/share/opencode/` to
  share auth tokens — `chown -R /home/agent/.local` hits the read-only
  file and exits non-zero
- GNU coreutils `chown -R` continues past individual errors and chowns
  all writable files correctly — only the exit code is non-zero
- Add `2>/dev/null || true` to both chown lines; ownership is
  best-effort before privilege drop, read-only mounts don't need it
- Matches existing pattern for SSH socket chown on line 76