### PR TITLE
chore(dockerfile): bump opencode to v1.4.6

### DIFF
--- a/internal/embed/assets/Dockerfile
+++ b/internal/embed/assets/Dockerfile
@@ -28,7 +28,7 @@ ARG PYRIGHT_VERSION=1.1.408
 # renovate: datasource=npm depName=bash-language-server
 ARG BASH_LS_VERSION=5.6.0
 # renovate: datasource=github-releases depName=sst/opencode
-ARG OPENCODE_VERSION=v1.3.17
+ARG OPENCODE_VERSION=v1.4.6
 
 # =============================================================================
 # Builder stage — compile language servers and install npm modules.


### PR DESCRIPTION
## Summary
- Bump embedded OpenCode from v1.3.17 to v1.4.6
- Adds fast mode variants (low/medium/high) for GitHub Copilot models (v1.4.3)
- Aligns GitHub Copilot Anthropic reasoning levels (v1.4.0)
- Fixes GitHub Copilot compaction requests (v1.4.4)
- Fixes snapshot staging for very long file lists (v1.4.6)