### PR TITLE
fix(entrypoint): suppress chown errors on read-only bind mounts

### DIFF
--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -70,15 +70,15 @@ iptables -A OUTPUT -d 192.168.0.0/16 -j DROP
 iptables -A OUTPUT -d 169.254.0.0/16 -j DROP
 iptables -A OUTPUT -d 100.64.0.0/10 -j DROP
 
-chown -R 1000:1000 /home/agent/.local /home/agent/.cache
-chown 1000:1000 /home/agent/.claude
+chown -R 1000:1000 /home/agent/.local /home/agent/.cache 2>/dev/null || true
+chown 1000:1000 /home/agent/.claude 2>/dev/null || true
 
 if [ -S /run/ssh-agent.sock ]; then
   chown 1000:1000 /run/ssh-agent.sock 2>/dev/null || true
 fi
 
 if [ -d /home/agent/.ssh ]; then
-  chown 1000:1000 /home/agent/.ssh
+  chown 1000:1000 /home/agent/.ssh 2>/dev/null || true
 fi
 
 exec setpriv --reuid=1000 --regid=1000 --init-groups --inh-caps=-all --no-new-privs -- env HOME=/home/agent "$@"


### PR DESCRIPTION
## Summary

- Make all `chown` calls best-effort (`2>/dev/null || true`) — read-only bind mounts inside chowned trees cause EPERM under `set -e`, killing the entrypoint
- Matches existing pattern for SSH socket chown (line 77)
- Continues from #69 (merged) which fixed the `.claude` recursion case

Co-authored-by: Jan Trnka <jan.trnka@firma.seznam.cz>