### PR TITLE
fix(up): detect port conflicts before starting workspace

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -74,6 +74,14 @@ func runUp(ctx context.Context, args []string) error {
 		return nil
 	}
 
+	runningPorts, err := docker.RunningWorkspacePorts(ctx)
+	if err != nil {
+		return fmt.Errorf("check running workspace ports: %w", err)
+	}
+	if err := checkPortConflict(runningPorts, ws.Name, ws.Port); err != nil {
+		return err
+	}
+
 	_, _ = color.New(color.FgCyan).Printf("Resolving image for workspace %s...\n", ws.Name)
 	finalImage, err := ResolveAndLayerImage(ctx, cfg, ws, appVersion)
 	if err != nil {
@@ -222,6 +230,21 @@ func isComposeFileMissing(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "no such file or directory") ||
 		strings.Contains(msg, "open ") && strings.Contains(msg, "docker-compose.yml")
+}
+
+// checkPortConflict returns an error if another running workspace already
+// occupies the target port. It skips the target workspace itself (a restart
+// scenario where the container is still shutting down).
+func checkPortConflict(ports map[string]int, targetName string, targetPort int) error {
+	for name, port := range ports {
+		if name == targetName {
+			continue
+		}
+		if port == targetPort {
+			return fmt.Errorf("port %d is already in use by running workspace %q — stop it first with: jailoc down %s", targetPort, name, name)
+		}
+	}
+	return nil
 }
 
 // writeEntrypoint writes the embedded entrypoint.sh to the workspace cache dir

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -496,10 +496,8 @@ func TestCheckPortConflict(t *testing.T) {
 				if !strings.Contains(err.Error(), tc.errSubstr) {
 					t.Fatalf("error %q should contain %q", err.Error(), tc.errSubstr)
 				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/seznam/jailoc/internal/embed"
@@ -438,4 +439,68 @@ func TestWriteEntrypointToCache(t *testing.T) {
 			t.Fatalf("expected permissions 0o755, got %o", info.Mode().Perm())
 		}
 	})
+}
+
+func TestCheckPortConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ports      map[string]int
+		targetName string
+		targetPort int
+		wantErr    bool
+		errSubstr  string
+	}{
+		{
+			name:       "no conflict",
+			ports:      map[string]int{"alpha": 4096},
+			targetName: "beta",
+			targetPort: 4097,
+			wantErr:    false,
+		},
+		{
+			name:       "conflict with another workspace",
+			ports:      map[string]int{"alpha": 4096},
+			targetName: "beta",
+			targetPort: 4096,
+			wantErr:    true,
+			errSubstr:  "alpha",
+		},
+		{
+			name:       "same workspace is not a conflict",
+			ports:      map[string]int{"alpha": 4096},
+			targetName: "alpha",
+			targetPort: 4096,
+			wantErr:    false,
+		},
+		{
+			name:       "empty map",
+			ports:      map[string]int{},
+			targetName: "alpha",
+			targetPort: 4096,
+			wantErr:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkPortConflict(tc.ports, tc.targetName, tc.targetPort)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("error %q should contain %q", err.Error(), tc.errSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -16,6 +16,8 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/docker/docker/api/types/build"
+	dcontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/fatih/color"
@@ -526,4 +528,46 @@ func resolveOverlayBuildContext(ws workspace.Resolved) (dir string, cleanup func
 	}
 
 	return tmpDir, func() { _ = os.RemoveAll(tmpDir) }, nil
+}
+
+// RunningWorkspacePorts returns a map of workspace name → published host port
+// for all running jailoc opencode containers.
+func RunningWorkspacePorts(ctx context.Context) (map[string]int, error) {
+	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, fmt.Errorf("create docker client: %w", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	containers, err := cli.ContainerList(ctx, dcontainer.ListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("label", "com.docker.compose.service=opencode"),
+			filters.Arg("status", "running"),
+		),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list containers: %w", err)
+	}
+
+	return workspacePortsFromContainers(containers), nil
+}
+
+// workspacePortsFromContainers extracts workspace name → published host port
+// from a list of Docker containers. Only containers belonging to jailoc compose
+// projects (project label prefixed with "jailoc-") are included.
+func workspacePortsFromContainers(containers []dcontainer.Summary) map[string]int {
+	result := make(map[string]int, len(containers))
+	for _, ct := range containers {
+		name, ok := strings.CutPrefix(ct.Labels["com.docker.compose.project"], "jailoc-")
+		if !ok {
+			continue
+		}
+		for _, p := range ct.Ports {
+			if p.PrivatePort == uint16(workspace.BasePort) && p.PublicPort != 0 {
+				result[name] = int(p.PublicPort)
+				break
+			}
+		}
+	}
+	return result
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/compose/v5/pkg/api"
+	dcontainer "github.com/docker/docker/api/types/container"
 	containertypes "github.com/moby/moby/api/types/container"
 
 	"github.com/seznam/jailoc/internal/config"
@@ -329,5 +330,124 @@ func TestBuildOverlayImageDockerfileLoadError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), nonExistentPath) {
 		t.Fatalf("unexpected error: got %q, want path %q", err.Error(), nonExistentPath)
+	}
+}
+
+func TestWorkspacePortsFromContainers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		containers []dcontainer.Summary
+		want       map[string]int
+	}{
+		{
+			name: "single workspace with correct labels and port",
+			containers: []dcontainer.Summary{
+				{
+					Labels: map[string]string{
+						"com.docker.compose.project": "jailoc-default",
+						"com.docker.compose.service": "opencode",
+					},
+					Ports: []dcontainer.Port{
+						{PrivatePort: uint16(workspace.BasePort), PublicPort: 4096},
+					},
+				},
+			},
+			want: map[string]int{"default": 4096},
+		},
+		{
+			name: "hyphenated workspace name",
+			containers: []dcontainer.Summary{
+				{
+					Labels: map[string]string{
+						"com.docker.compose.project": "jailoc-my-app",
+						"com.docker.compose.service": "opencode",
+					},
+					Ports: []dcontainer.Port{
+						{PrivatePort: uint16(workspace.BasePort), PublicPort: 4097},
+					},
+				},
+			},
+			want: map[string]int{"my-app": 4097},
+		},
+		{
+			name: "non-jailoc project label is skipped",
+			containers: []dcontainer.Summary{
+				{
+					Labels: map[string]string{
+						"com.docker.compose.project": "other-project",
+						"com.docker.compose.service": "opencode",
+					},
+					Ports: []dcontainer.Port{
+						{PrivatePort: uint16(workspace.BasePort), PublicPort: 9999},
+					},
+				},
+			},
+			want: map[string]int{},
+		},
+		{
+			name: "no published port is skipped",
+			containers: []dcontainer.Summary{
+				{
+					Labels: map[string]string{
+						"com.docker.compose.project": "jailoc-default",
+						"com.docker.compose.service": "opencode",
+					},
+					Ports: []dcontainer.Port{
+						{PrivatePort: uint16(workspace.BasePort), PublicPort: 0},
+					},
+				},
+			},
+			want: map[string]int{},
+		},
+		{
+			name: "multiple workspaces",
+			containers: []dcontainer.Summary{
+				{
+					Labels: map[string]string{
+						"com.docker.compose.project": "jailoc-alpha",
+					},
+					Ports: []dcontainer.Port{
+						{PrivatePort: uint16(workspace.BasePort), PublicPort: 4096},
+					},
+				},
+				{
+					Labels: map[string]string{
+						"com.docker.compose.project": "jailoc-beta",
+					},
+					Ports: []dcontainer.Port{
+						{PrivatePort: uint16(workspace.BasePort), PublicPort: 4097},
+					},
+				},
+			},
+			want: map[string]int{"alpha": 4096, "beta": 4097},
+		},
+		{
+			name:       "empty container list",
+			containers: []dcontainer.Summary{},
+			want:       map[string]int{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := workspacePortsFromContainers(tc.containers)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d entries, want %d: %v", len(got), len(tc.want), got)
+			}
+			for name, wantPort := range tc.want {
+				gotPort, ok := got[name]
+				if !ok {
+					t.Fatalf("missing workspace %q in result: %v", name, got)
+				}
+				if gotPort != wantPort {
+					t.Fatalf("workspace %q: got port %d, want %d", name, gotPort, wantPort)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Query running jailoc containers for their published host ports before starting a workspace
- Return a clear error with remediation hint (`jailoc down <name>`) when another workspace already occupies the target port
- Skip self-collision to allow restarts while a container is still shutting down