### PR TITLE
docs: add pre-commit checks to AGENTS.md and development.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,17 @@ GitHub Actions workflows:
 - **Re-release** (`.github/workflows/release.yml`): manual `workflow_dispatch` fallback — re-runs GoReleaser for an existing tag
 - **Docs** (`.github/workflows/release-please.yml`): runs as part of the release process — zensical + mkdocs-macros-plugin → GitHub Pages
 
+## Before committing
+
+Run these locally and fix all failures before staging a commit:
+
+```sh
+go build ./...
+go test ./...
+go vet ./...
+golangci-lint run
+```
+
 ## Commits
 
 `type(scope): description` — types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`. Imperative mood.

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,9 @@ This page is for contributors. It covers how to build and test the project local
 # Build the binary
 go build ./cmd/jailoc
 
+# Verify all packages compile (pre-commit)
+go build ./...
+
 # Run unit tests
 go test ./...
 
@@ -21,6 +24,7 @@ go test -tags=integration ./internal/...
 
 # Lint
 go vet ./...
+golangci-lint run
 ```
 
 ## CI/CD pipeline


### PR DESCRIPTION
Documents the required pre-commit checks (`go build`, `go test`, `go vet`, `golangci-lint run`) in both AGENTS.md and the contributor guide.