### PR TITLE
fix(test): use docker/docker client and avoid /tmp workspace paths in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .envrc
 .sisyphus/
+.integration-tmp/
 jailoc
 .DS_Store
 all.md

--- a/internal/docker/docker_integration_test.go
+++ b/internal/docker/docker_integration_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moby/moby/api/types/image"
-	dockerclient "github.com/moby/moby/client"
+	"github.com/docker/docker/api/types/image"
+	dockerclient "github.com/docker/docker/client"
 
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/workspace"
@@ -21,12 +21,12 @@ func skipWithoutDocker(t *testing.T) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cli, err := dockerclient.New()
+	cli, err := dockerclient.NewClientWithOpts()
 	if err != nil {
 		t.Skip("Docker client not available: ", err)
 	}
 	defer func() { _ = cli.Close() }()
-	if _, err := cli.Ping(ctx, dockerclient.PingOptions{}); err != nil {
+	if _, err := cli.Ping(ctx); err != nil {
 		t.Skip("Docker daemon not reachable: ", err)
 	}
 }
@@ -101,7 +101,7 @@ func TestBuildEmbeddedImage(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	cli, err := dockerclient.New(dockerclient.WithAPIVersionNegotiation())
+	cli, err := dockerclient.NewClientWithOpts(dockerclient.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatalf("create Docker client: %v", err)
 	}

--- a/internal/docker/docker_integration_test.go
+++ b/internal/docker/docker_integration_test.go
@@ -21,7 +21,7 @@ func skipWithoutDocker(t *testing.T) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	cli, err := dockerclient.NewClientWithOpts()
+	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Skip("Docker client not available: ", err)
 	}
@@ -101,7 +101,7 @@ func TestBuildEmbeddedImage(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	cli, err := dockerclient.NewClientWithOpts(dockerclient.WithAPIVersionNegotiation())
+	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
 	if err != nil {
 		t.Fatalf("create Docker client: %v", err)
 	}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -106,7 +106,7 @@ func TestUpStatusDownLifecycle(t *testing.T) {
 	}
 
 	home := testHome(t)
-	if err := writeMinimalConfig(home, t.TempDir()); err != nil {
+	if err := writeMinimalConfig(home, testWorkspaceDir(t)); err != nil {
 		t.Fatalf("write minimal config: %v", err)
 	}
 
@@ -145,12 +145,12 @@ func TestAddPathPersists(t *testing.T) {
 	defer cancel()
 
 	home := testHome(t)
-	workspaceDir := t.TempDir()
+	workspaceDir := testWorkspaceDir(t)
 	if err := writeMinimalConfig(home, workspaceDir); err != nil {
 		t.Fatalf("write minimal config: %v", err)
 	}
 
-	addDir := t.TempDir()
+	addDir := testWorkspaceDir(t)
 	addOut, addErr := runJailoc(ctx, home, "add", addDir)
 	if addErr != nil {
 		t.Fatalf("run jailoc add: %v\noutput:\n%s", addErr, addOut)
@@ -205,7 +205,7 @@ func TestUpIdempotent(t *testing.T) {
 	}
 
 	home := testHome(t)
-	if err := writeMinimalConfig(home, t.TempDir()); err != nil {
+	if err := writeMinimalConfig(home, testWorkspaceDir(t)); err != nil {
 		t.Fatalf("write minimal config: %v", err)
 	}
 
@@ -240,7 +240,7 @@ func TestEnvVarsReachContainer(t *testing.T) {
 	}
 
 	home := testHome(t)
-	workspaceDir := t.TempDir()
+	workspaceDir := testWorkspaceDir(t)
 
 	configPath := filepath.Join(home, ".config", "jailoc", "config.toml")
 	content := fmt.Sprintf(`[base]
@@ -286,7 +286,7 @@ func TestEnvFileVarsReachContainer(t *testing.T) {
 	}
 
 	home := testHome(t)
-	workspaceDir := t.TempDir()
+	workspaceDir := testWorkspaceDir(t)
 
 	envFile, err := os.CreateTemp("", "jailoc-integration-*.env")
 	if err != nil {
@@ -349,6 +349,23 @@ func projectRoot() string {
 		}
 		dir = parent
 	}
+}
+
+// testWorkspaceDir creates a temp directory under the project root instead of
+// os.TempDir(). Workspace paths under /tmp conflict with forbiddenMountPrefixes
+// validation, which blocks /tmp as a container-internal directory.
+func testWorkspaceDir(t *testing.T) string {
+	t.Helper()
+	base := filepath.Join(projectRoot(), ".integration-tmp")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("create workspace base dir %q: %v", base, err)
+	}
+	dir, err := os.MkdirTemp(base, "ws-")
+	if err != nil {
+		t.Fatalf("create test workspace dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 func testHome(t *testing.T) string {
@@ -453,7 +470,7 @@ func TestHealthEndpointAccessible(t *testing.T) {
 	}
 
 	home := testHome(t)
-	workspaceDir := t.TempDir()
+	workspaceDir := testWorkspaceDir(t)
 
 	content := fmt.Sprintf(`[base]
 

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -68,6 +68,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	cleanupAllHomes()
+	_ = os.RemoveAll(filepath.Join(projectRoot(), ".integration-tmp"))
 	if err := os.Setenv("HOME", oldHome); err != nil {
 		fmt.Fprintf(os.Stderr, "restore HOME: %v\n", err)
 	}
@@ -364,7 +365,6 @@ func testWorkspaceDir(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("create test workspace dir: %v", err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return dir
 }
 


### PR DESCRIPTION
## Summary

- Switch `docker_integration_test.go` imports from `moby/moby` to `docker/docker` to match production code's `APIClient` interface (fixes build failure)
- Replace `t.TempDir()` with project-root-based temp dirs in integration tests to avoid `/tmp` forbidden prefix validation