### PR TITLE
fix(up): require non-empty OPENCODE_SERVER_PASSWORD

### DIFF
--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -295,13 +295,13 @@ Use [direnv](https://direnv.net/) to set a unique `OPENCODE_SERVER_PASSWORD` per
 1. Generate a password and write it to an untracked file in the workspace root:
 
    ```bash
-   echo "export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)" > .env.local
+   echo "OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)" > .env.local
    ```
 
 2. Add `.env.local` to `.gitignore`, then load it from `.envrc`:
 
    ```bash
-   echo "source_env_if_exists .env.local" >> .envrc
+   echo "dotenv_if_exists .env.local" >> .envrc
    direnv allow
    ```
 

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -285,3 +285,24 @@ memory = "16g"
 ```
 
 Both fields are optional. Workspace values override defaults; when neither is set, the fallback is `2.0` CPU cores and `"4g"` memory. The `memory` field accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` (e.g. `512m`, `4g`, `1024`).
+
+---
+
+## Set a per-workspace password
+
+Use [direnv](https://direnv.net/) to set a unique `OPENCODE_SERVER_PASSWORD` per workspace, so a compromised credential only affects that one workspace.
+
+1. Generate a password and write it to an untracked file in the workspace root:
+
+   ```bash
+   echo "export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)" > .env.local
+   ```
+
+2. Add `.env.local` to `.gitignore`, then load it from `.envrc`:
+
+   ```bash
+   echo "source_env_if_exists .env.local" >> .envrc
+   direnv allow
+   ```
+
+`cd` into the workspace directory before running `jailoc up` or `jailoc` so direnv loads the correct password.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,6 +34,8 @@ When run from a subdirectory of a workspace path, jailoc resolves the current wo
 
 When neither `--remote` nor `--exec` is specified, the connection mode is determined by the workspace `mode` field in configuration, falling back to auto-detection (checks for `opencode`, then `opencode-cli` on PATH). See the [access modes how-to](../how-to/access-modes.md) for configuration steps, or the [access modes explanation](../explanation/access-modes.md) for the difference between modes.
 
+*Note: Starting a workspace requires `OPENCODE_SERVER_PASSWORD`. See [`jailoc up`](#jailoc-up) for details.*
+
 ---
 
 ### `jailoc up`
@@ -43,6 +45,14 @@ Start the Docker Compose environment for the target workspace. No-op if the work
 ```
 jailoc up [flags]
 ```
+
+!!! warning "OPENCODE_SERVER_PASSWORD required"
+
+    `jailoc up` requires `OPENCODE_SERVER_PASSWORD` to be set in the environment.
+    An empty password leaves the OpenCode server unauthenticated.
+    See [Getting Started](../tutorials/getting-started.md) for setup instructions.
+
+    If the workspace is already running but was started without a password, `jailoc up` prints a warning with restart instructions.
 
 Resolves the container image (see [Image Resolution](image-resolution.md)), generates a `docker-compose.yml` in `~/.cache/jailoc/{workspace}/`, and starts two containers: `opencode` and `dind`.
 
@@ -115,3 +125,5 @@ jailoc add [flags]
 Appends the current directory to `workspaces.<name>.paths` in `~/.config/jailoc/config.toml`. The path must not be under a forbidden system prefix. See the [configuration reference](configuration.md) for path validation rules.
 
 When `--workspace` is not set, resolves the workspace from the path being added (longest prefix). If `--workspace` is set explicitly and the path is not under any of that workspace's configured paths, `jailoc add` returns an error. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
+
+*Note: If the workspace is already running, `jailoc add` restarts it to apply the new mount. This requires `OPENCODE_SERVER_PASSWORD`. See [`jailoc up`](#jailoc-up) for details.*

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -30,6 +30,21 @@ jailoc --version
 
 ## Run your first workspace
 
+Before starting a workspace, set a password for the OpenCode server. jailoc passes this to `opencode serve` and refuses to start containers without it.
+
+Generate the password **once** and append its literal value to your shell config (this saves the fixed hex string, not the command itself):
+
+```bash
+echo "export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)" >> ~/.bashrc
+source ~/.bashrc
+```
+
+Replace `.bashrc` with `.zshrc` or your shell's equivalent. Then confirm the variable is set:
+
+```bash
+echo ${#OPENCODE_SERVER_PASSWORD}   # should print 64
+```
+
 The quickest way to get started is to run `jailoc` without any arguments from your project directory:
 
 ```bash

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -94,6 +94,21 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return nil
 	}
 
+	// Guard before any Docker work: if the compose file exists a restart is
+	// possible and a missing password would start opencode unauthenticated.
+	// Placed after the compose-file check so workspaces that have never been
+	// started (no compose file) pass through without requiring the password.
+	// Workspaces that are currently stopped but have a compose file will hit
+	// this guard because it must be evaluated before hitting the Docker daemon
+	// to check the running status.
+	if os.Getenv("OPENCODE_SERVER_PASSWORD") == "" {
+		return fmt.Errorf(
+			"OPENCODE_SERVER_PASSWORD is not set\n" +
+				"set it before starting or restarting a workspace:\n\n" +
+				"  export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)",
+		)
+	}
+
 	client := docker.NewClient(compPath, "", ws.Name)
 
 	running, err := client.IsRunning(ctx)

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -91,7 +91,10 @@ func isDuplicate(paths []string, target string) bool {
 func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 	compPath := filepath.Join(ComposeCacheDir(ws.Name), "docker-compose.yml")
 	if _, err := os.Stat(compPath); err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat compose file: %w", err)
 	}
 
 	// Guard before any Docker work: if the compose file exists a restart is

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -97,21 +97,6 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return fmt.Errorf("stat compose file: %w", err)
 	}
 
-	// Guard before any Docker work: if the compose file exists a restart is
-	// possible and a missing password would start opencode unauthenticated.
-	// Placed after the compose-file check so workspaces that have never been
-	// started (no compose file) pass through without requiring the password.
-	// Workspaces that are currently stopped but have a compose file will hit
-	// this guard because it must be evaluated before hitting the Docker daemon
-	// to check the running status.
-	if os.Getenv("OPENCODE_SERVER_PASSWORD") == "" {
-		return fmt.Errorf(
-			"OPENCODE_SERVER_PASSWORD is not set\n" +
-				"set it before starting or restarting a workspace:\n\n" +
-				"  export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)",
-		)
-	}
-
 	client := docker.NewClient(compPath, "", ws.Name)
 
 	running, err := client.IsRunning(ctx)
@@ -121,6 +106,17 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 
 	if !running {
 		return nil
+	}
+
+	// Guard before regenerating the compose file and restarting: a missing
+	// password would start opencode unauthenticated. Only reached when the
+	// workspace is confirmed running and a restart is required.
+	if os.Getenv("OPENCODE_SERVER_PASSWORD") == "" {
+		return fmt.Errorf(
+			"OPENCODE_SERVER_PASSWORD is not set\n" +
+				"set it before starting or restarting a workspace:\n\n" +
+				"  export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)",
+		)
 	}
 
 	cfg, err := config.Load()

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/seznam/jailoc/internal/workspace"
@@ -127,13 +126,13 @@ func TestAddComposePath(t *testing.T) {
 // TestMaybeRestartWorkspace exercises maybeRestartWorkspace for cases that do
 // not require Docker. Uses t.Setenv, so no t.Parallel().
 func TestMaybeRestartWorkspace(t *testing.T) {
-	t.Run("returns error when OPENCODE_SERVER_PASSWORD is unset", func(t *testing.T) {
+	t.Run("returns nil without password when workspace is stopped", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		t.Setenv("OPENCODE_SERVER_PASSWORD", "")
 
-		// Create the compose file so the function reaches the password guard
-		// rather than returning nil at the "compose file missing" early exit.
+		// Create the compose file so the function proceeds past the stat check.
+		// IsRunning will fail (no Docker), returning nil before the password guard.
 		ws := &workspace.Resolved{Name: "test"}
 		compDir := ComposeCacheDir(ws.Name)
 		if err := os.MkdirAll(compDir, 0o750); err != nil {
@@ -143,12 +142,10 @@ func TestMaybeRestartWorkspace(t *testing.T) {
 			t.Fatalf("write compose file: %v", err)
 		}
 
+		// No Docker available — IsRunning returns an error, function returns nil.
 		err := maybeRestartWorkspace(context.Background(), ws)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "OPENCODE_SERVER_PASSWORD") {
-			t.Fatalf("error %q should contain %q", err.Error(), "OPENCODE_SERVER_PASSWORD")
+		if err != nil {
+			t.Fatalf("expected nil for stopped workspace, got: %v", err)
 		}
 	})
 }

--- a/internal/cmd/add_test.go
+++ b/internal/cmd/add_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/seznam/jailoc/internal/workspace"
 )
 
 func TestIsDuplicate(t *testing.T) {
@@ -116,6 +120,35 @@ func TestAddComposePath(t *testing.T) {
 		expected := filepath.Join(os.TempDir(), "jailoc", "test-workspace", "docker-compose.yml")
 		if got != expected {
 			t.Errorf("fallback compose path = %q, want %q", got, expected)
+		}
+	})
+}
+
+// TestMaybeRestartWorkspace exercises maybeRestartWorkspace for cases that do
+// not require Docker. Uses t.Setenv, so no t.Parallel().
+func TestMaybeRestartWorkspace(t *testing.T) {
+	t.Run("returns error when OPENCODE_SERVER_PASSWORD is unset", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("OPENCODE_SERVER_PASSWORD", "")
+
+		// Create the compose file so the function reaches the password guard
+		// rather than returning nil at the "compose file missing" early exit.
+		ws := &workspace.Resolved{Name: "test"}
+		compDir := ComposeCacheDir(ws.Name)
+		if err := os.MkdirAll(compDir, 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(compDir, "docker-compose.yml"), []byte("services: {}"), 0o600); err != nil {
+			t.Fatalf("write compose file: %v", err)
+		}
+
+		err := maybeRestartWorkspace(context.Background(), ws)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "OPENCODE_SERVER_PASSWORD") {
+			t.Fatalf("error %q should contain %q", err.Error(), "OPENCODE_SERVER_PASSWORD")
 		}
 	})
 }

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -264,7 +264,12 @@ func isRunningPasswordless(composePath string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(string(data), "OPENCODE_SERVER_PASSWORD=\n")
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasSuffix(strings.TrimRight(line, "\r"), "OPENCODE_SERVER_PASSWORD=") {
+			return true
+		}
+	}
+	return false
 }
 
 // checkPortConflict returns an error if another running workspace already

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -55,6 +55,16 @@ func runUp(ctx context.Context, args []string) error {
 		return fmt.Errorf("resolve workspace %q: %w", workspaceFlag, err)
 	}
 
+	// Guard before any Docker work: a missing password would start opencode
+	// with no authentication.
+	if os.Getenv("OPENCODE_SERVER_PASSWORD") == "" {
+		return fmt.Errorf(
+			"OPENCODE_SERVER_PASSWORD is not set\n" +
+				"set it before starting a workspace:\n\n" +
+				"  export OPENCODE_SERVER_PASSWORD=$(openssl rand -hex 32)",
+		)
+	}
+
 	_, _ = color.New(color.FgCyan).Printf("Checking Docker availability...\n")
 	if err := preflightDocker(ctx, ws.Name); err != nil {
 		return fmt.Errorf("docker is not running or not accessible: %w", err)
@@ -70,6 +80,18 @@ func runUp(ctx context.Context, args []string) error {
 		running = false
 	}
 	if running {
+		// Warn if the workspace was started without a password (e.g. before
+		// the guard was introduced). Detection reads the cached compose file
+		// and checks whether the password line is empty. Returns false on any
+		// read error so a missing file never produces a spurious warning.
+		if isRunningPasswordless(composePath) {
+			_, _ = color.New(color.FgYellow).Printf(
+				"Warning: workspace %s is running without a password — the OpenCode server is unauthenticated.\n"+
+					"Restart it to secure the connection:\n\n"+
+					"  jailoc down %s && jailoc up %s\n\n",
+				ws.Name, ws.Name, ws.Name,
+			)
+		}
 		_, _ = color.New(color.FgYellow).Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
 		return nil
 	}
@@ -230,6 +252,19 @@ func isComposeFileMissing(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "no such file or directory") ||
 		strings.Contains(msg, "open ") && strings.Contains(msg, "docker-compose.yml")
+}
+
+// isRunningPasswordless reports whether the workspace's cached compose file
+// was generated with an empty OPENCODE_SERVER_PASSWORD. This indicates the
+// workspace was started before the password guard was introduced. Returns
+// false on any read error so a missing or unreadable file never triggers a
+// spurious warning.
+func isRunningPasswordless(composePath string) bool {
+	data, err := os.ReadFile(composePath) //nolint:gosec // path is constructed internally from the workspace cache dir
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "OPENCODE_SERVER_PASSWORD=\n")
 }
 
 // checkPortConflict returns an error if another running workspace already

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -536,6 +536,30 @@ func TestIsRunningPasswordless(t *testing.T) {
 		}
 	})
 
+	t.Run("returns true with CRLF line endings", func(t *testing.T) {
+		t.Parallel()
+		f := filepath.Join(t.TempDir(), "docker-compose.yml")
+		content := "    environment:\r\n      - OPENCODE_SERVER_PASSWORD=\r\n      - DOCKER_HOST=tcp://dind:2376\r\n"
+		if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !isRunningPasswordless(f) {
+			t.Fatal("expected true for empty password line with CRLF")
+		}
+	})
+
+	t.Run("returns true when file has no trailing newline", func(t *testing.T) {
+		t.Parallel()
+		f := filepath.Join(t.TempDir(), "docker-compose.yml")
+		content := "    environment:\n      - OPENCODE_SERVER_PASSWORD="
+		if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !isRunningPasswordless(f) {
+			t.Fatal("expected true for empty password line without trailing newline")
+		}
+	})
+
 	t.Run("returns false when password is set", func(t *testing.T) {
 		t.Parallel()
 		f := filepath.Join(t.TempDir(), "docker-compose.yml")

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -501,4 +502,56 @@ func TestCheckPortConflict(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRunUp exercises runUp itself for cases that do not require Docker.
+// Uses t.Setenv, so no t.Parallel().
+func TestRunUp(t *testing.T) {
+	t.Run("returns error when OPENCODE_SERVER_PASSWORD is unset", func(t *testing.T) {
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("OPENCODE_SERVER_PASSWORD", "")
+
+		err := runUp(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "OPENCODE_SERVER_PASSWORD") {
+			t.Fatalf("error %q should contain %q", err.Error(), "OPENCODE_SERVER_PASSWORD")
+		}
+	})
+}
+
+func TestIsRunningPasswordless(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns true when password line is empty", func(t *testing.T) {
+		t.Parallel()
+		f := filepath.Join(t.TempDir(), "docker-compose.yml")
+		content := "    environment:\n      - OPENCODE_SERVER_PASSWORD=\n      - DOCKER_HOST=tcp://dind:2376\n"
+		if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !isRunningPasswordless(f) {
+			t.Fatal("expected true for empty password line")
+		}
+	})
+
+	t.Run("returns false when password is set", func(t *testing.T) {
+		t.Parallel()
+		f := filepath.Join(t.TempDir(), "docker-compose.yml")
+		content := "    environment:\n      - OPENCODE_SERVER_PASSWORD=hunter2\n      - DOCKER_HOST=tcp://dind:2376\n"
+		if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if isRunningPasswordless(f) {
+			t.Fatal("expected false for set password")
+		}
+	})
+
+	t.Run("returns false when file does not exist", func(t *testing.T) {
+		t.Parallel()
+		if isRunningPasswordless(filepath.Join(t.TempDir(), "docker-compose.yml")) {
+			t.Fatal("expected false for missing file")
+		}
+	})
 }


### PR DESCRIPTION
Fixes #97 

- Prevent unauthenticated OpenCode server access by failing fast
- Warn on insecure legacy workspaces to prompt restarts
- Document direnv pattern to limit credential blast radius