### PR TITLE
fix(password): use Peek for migration detection to support all password modes

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -124,8 +124,12 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 			}
 		} else {
-			_, hasPasswordErr := password.ReadPasswordFile(ws.Name)
-			if hasPasswordErr != nil {
+			resolver := password.DefaultResolver(false, cfg.PasswordMode)
+			pwSource, peekErr := resolver.Peek(ws.Name)
+			if peekErr != nil {
+				return fmt.Errorf("check password for workspace %q: %w", ws.Name, peekErr)
+			}
+			if pwSource == "" {
 				workspaceExplicit = true
 				if err := runUp(ctx, nil); err != nil {
 					return fmt.Errorf("migrate workspace %q: %w", ws.Name, err)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/seznam/jailoc/internal/password"
 	"github.com/seznam/jailoc/internal/workspace"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var workspaceFlag string
@@ -124,7 +125,8 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 			}
 		} else {
-			resolver := password.DefaultResolver(false, cfg.PasswordMode)
+			interactive := term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // G115: uintptr→int is safe for file descriptors
+			resolver := password.DefaultResolver(interactive, cfg.PasswordMode)
 			pwSource, peekErr := resolver.Peek(ws.Name)
 			if peekErr != nil {
 				return fmt.Errorf("check password for workspace %q: %w", ws.Name, peekErr)

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -75,8 +75,11 @@ func runUp(ctx context.Context, args []string) error {
 
 	interactive := term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // G115: uintptr→int is safe for file descriptors
 	resolver := password.DefaultResolver(interactive, cfg.PasswordMode)
-	_, hasPasswordErr := password.ReadPasswordFile(ws.Name)
-	hasPassword := hasPasswordErr == nil
+	pwSource, err := resolver.Peek(ws.Name)
+	if err != nil {
+		return fmt.Errorf("check password for workspace %q: %w", ws.Name, err)
+	}
+	hasPassword := pwSource != ""
 
 	if needsMigration(running, hasPassword) {
 		_, _ = color.New(color.FgYellow).Printf("Workspace %s is running without a password.\n", ws.Name)


### PR DESCRIPTION
Migration detection in `up.go` and `root.go` used `ReadPasswordFile` which only checks for a password file on disk. This caused false-positive migration prompts for `keyring` and `env` password modes where no file is ever written.

Replaced with `Resolver.Peek()` which checks all configured sources (env, keyring, file).