### PR TITLE
feat(config): add expose_port option to disable host port exposure

### DIFF
--- a/docs/explanation/access-modes.md
+++ b/docs/explanation/access-modes.md
@@ -77,6 +77,6 @@ This means the default behaviour changes depending on your host environment. A m
 
 You can override auto-detection by setting `mode` explicitly in your workspace config. This is useful if you have opencode installed but want exec mode for a specific workspace, or if you want to lock the behaviour for predictability in shared setups.
 
-When `expose_port` is `false` for a workspace, the container port is not published to the host, so remote mode is unavailable. The workspace is only accessible via exec mode regardless of the `mode` setting. See [Configuration Reference](../reference/configuration.md) for details on the `expose_port` field.
+When `expose_port` is `false` for a workspace, the container port is not published to the host, so remote mode is unavailable. In that case, configure `mode = "exec"` for the workspace or use `jailoc attach --exec` when attaching. See [Configuration Reference](../reference/configuration.md) for details on the `expose_port` field.
 
 For configuration instructions, see [How-to: Access Modes](../how-to/access-modes.md). For CLI flags that affect attachment behaviour, see [CLI Reference](../reference/cli.md).

--- a/docs/explanation/access-modes.md
+++ b/docs/explanation/access-modes.md
@@ -77,4 +77,6 @@ This means the default behaviour changes depending on your host environment. A m
 
 You can override auto-detection by setting `mode` explicitly in your workspace config. This is useful if you have opencode installed but want exec mode for a specific workspace, or if you want to lock the behaviour for predictability in shared setups.
 
+When `expose_port` is `false` for a workspace, the container port is not published to the host, so remote mode is unavailable. The workspace is only accessible via exec mode regardless of the `mode` setting. See [Configuration Reference](../reference/configuration.md) for details on the `expose_port` field.
+
 For configuration instructions, see [How-to: Access Modes](../how-to/access-modes.md). For CLI flags that affect attachment behaviour, see [CLI Reference](../reference/cli.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,7 @@ Print the state and assigned port for each configured workspace.
 jailoc status [flags]
 ```
 
-Output lists all workspaces defined in configuration. For each workspace, shows the container state (running, stopped, or unknown) and the host port it is assigned. Workspaces with `expose_port = false` show "not exposed (exec-only)" instead of a port number.
+Output shows the container state (running, stopped, or unknown) and the assigned host port for the resolved workspace. Workspaces with `expose_port = false` show "not exposed (exec-only)" instead of a port number.
 
 When `--workspace` is not set, resolves the workspace whose configured path best matches the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,7 +72,7 @@ Print the state and assigned port for each configured workspace.
 jailoc status [flags]
 ```
 
-Output lists all workspaces defined in configuration. For each workspace, shows the container state (running, stopped, or unknown) and the host port it is assigned.
+Output lists all workspaces defined in configuration. For each workspace, shows the container state (running, stopped, or unknown) and the host port it is assigned. Workspaces with `expose_port = false` show "not exposed (exec-only)" instead of a port number.
 
 When `--workspace` is not set, resolves the workspace whose configured path best matches the current working directory (longest prefix). Falls back to `default`. See the [workspace configuration how-to](../how-to/workspace-configuration.md) for the full resolution order.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,7 +62,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 | `allowed_networks` | string[] | `[]` | CIDR ranges allowed through the firewall for all workspaces. Merged with per-workspace `allowed_networks`. |
 | `ssh_auth_sock` | bool | `false` | Mount the host SSH agent socket into the container. Auto-detects the socket: Docker Desktop/OrbStack magic path first, then `$SSH_AUTH_SOCK`. Also mounts `~/.ssh/known_hosts` read-only when enabled. |
 | `git_config` | bool | `true` | Mount the host Git configuration (`~/.gitconfig` or `~/.config/git/config`) read-only into the container. |
-| `expose_port` | bool | `true` | Expose the opencode container port to the host. When `false`, the `ports:` section is omitted from the generated compose file and the workspace is only accessible via `jailoc attach` in exec mode. |
+| `expose_port` | bool | `true` | Expose the opencode container port to the host. When `false`, the `ports:` section is omitted from the generated compose file and the workspace is only accessible via `jailoc --exec`. |
 | `cpu` | float64 | `2.0` | Number of CPU cores allocated to the opencode container. Must be greater than 0. |
 | `memory` | string | `"4g"` | Memory limit for the opencode container. Accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` suffix (e.g. `512m`, `4g`, `1024`). Must be greater than 0. |
 
@@ -275,7 +275,7 @@ Where `index` is the zero-based position of the workspace name when all workspac
 
 Port assignments shift when workspace names are added or removed. Run `jailoc status` to see current assignments.
 
-When `expose_port` is `false` for a workspace, the port is still allocated but not exposed to the host. The workspace is only accessible via `jailoc attach` in exec mode.
+When `expose_port` is `false` for a workspace, the port is still allocated but not exposed to the host. The workspace remains accessible via `jailoc --exec`, but `jailoc --remote` does not work because readiness detection and remote attach require a published localhost port.
 
 ---
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -62,6 +62,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 | `allowed_networks` | string[] | `[]` | CIDR ranges allowed through the firewall for all workspaces. Merged with per-workspace `allowed_networks`. |
 | `ssh_auth_sock` | bool | `false` | Mount the host SSH agent socket into the container. Auto-detects the socket: Docker Desktop/OrbStack magic path first, then `$SSH_AUTH_SOCK`. Also mounts `~/.ssh/known_hosts` read-only when enabled. |
 | `git_config` | bool | `true` | Mount the host Git configuration (`~/.gitconfig` or `~/.config/git/config`) read-only into the container. |
+| `expose_port` | bool | `true` | Expose the opencode container port to the host. When `false`, the `ports:` section is omitted from the generated compose file and the workspace is only accessible via `jailoc attach` in exec mode. |
 | `cpu` | float64 | `2.0` | Number of CPU cores allocated to the opencode container. Must be greater than 0. |
 | `memory` | string | `"4g"` | Memory limit for the opencode container. Accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` suffix (e.g. `512m`, `4g`, `1024`). Must be greater than 0. |
 
@@ -103,6 +104,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | `env_file` | string[] | `[]` | Paths to `.env` files for this workspace. Each file must exist at config load time. Paths must be absolute (`/...`) or start with `~`. Loaded after global `defaults.env_file` entries. |
 | `ssh_auth_sock` | bool | (inherit) | Mount the host SSH agent socket into the container. When not set, inherits from `[defaults]`. Also mounts `~/.ssh/known_hosts` read-only when enabled. |
 | `git_config` | bool | (inherit) | Mount the host Git configuration read-only into the container. When not set, inherits from `[defaults]`. Falls back to `true` when neither the workspace nor defaults set it. |
+| `expose_port` | bool | (inherit) | Expose the opencode container port to the host. When not set, inherits from `[defaults]`. Falls back to `true` when neither the workspace nor defaults set it. When `false`, `jailoc status` shows "not exposed (exec-only)" instead of the port number. |
 | `cpu` | float64 | (inherit) | Number of CPU cores allocated to the opencode container. When not set, inherits from `[defaults]`. Falls back to `2.0` when neither the workspace nor defaults set it. |
 | `memory` | string | (inherit) | Memory limit for the opencode container. When not set, inherits from `[defaults]`. Falls back to `"4g"` when neither the workspace nor defaults set it. |
 
@@ -249,7 +251,7 @@ Environment variables from multiple sources are merged in this order (later entr
 | `/home/agent/.claude/transcripts` | `~/.claude/transcripts` | `rw` |
 | `/home/agent/.agents` | `~/.agents` | `ro` |
 
-`ssh_auth_sock` and `git_config` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config` falls back to `true` when neither the workspace nor defaults set it.
+`ssh_auth_sock`, `git_config`, and `expose_port` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config` and `expose_port` fall back to `true` when neither the workspace nor defaults set it.
 
 `cpu` and `memory` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `cpu` falls back to `2.0` and `memory` falls back to `"4g"` when neither the workspace nor defaults set them.
 
@@ -272,6 +274,8 @@ Where `index` is the zero-based position of the workspace name when all workspac
 | `gamma` (index 2) | 4098 |
 
 Port assignments shift when workspace names are added or removed. Run `jailoc status` to see current assignments.
+
+When `expose_port` is `false` for a workspace, the port is still allocated but not exposed to the host. The workspace is only accessible via `jailoc attach` in exec mode.
 
 ---
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -142,6 +142,7 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		Memory:           ws2.Memory,
 		UseDataVolume:    !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.local/share/opencode"),
 		UseCacheVolume:   !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.cache"),
+		ExposePort:       ws2.ExposePort,
 	}
 
 	if err := config.WriteAllowedFiles(ws2.Name, cfg); err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -327,7 +327,7 @@ func waitForReadiness(ctx context.Context, port int, exposePort bool, dc *docker
 	if exposePort {
 		return waitForReady(ctx, port, dc)
 	}
-	return waitForReadyExec(ctx, port, dc)
+	return waitForReadyExec(ctx, workspace.BasePort, dc)
 }
 
 func waitForReady(ctx context.Context, port int, dc *docker.Client) error {
@@ -371,7 +371,7 @@ func waitForReadyExec(ctx context.Context, port int, dc *docker.Client) error {
 	ticker := time.NewTicker(readyPollInterval)
 	defer ticker.Stop()
 
-	probeArgs := []string{"curl", "-sf", fmt.Sprintf("http://localhost:%d", port)}
+	probeArgs := []string{"curl", "-s", fmt.Sprintf("http://localhost:%d", port)}
 
 	for {
 		state, exitCode, err := dc.ContainerState(ctx)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -121,11 +122,9 @@ var rootCmd = &cobra.Command{
 			if err := runUp(ctx, nil); err != nil {
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}
-			if ws.ExposePort {
-				_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
-				if err := waitForReady(ctx, ws.Port, client); err != nil {
-					return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
-				}
+			_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready...\n")
+			if err := waitForReadiness(ctx, ws.Port, ws.ExposePort, client); err != nil {
+				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 			}
 		} else {
 			interactive := term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // G115: uintptr→int is safe for file descriptors
@@ -139,11 +138,9 @@ var rootCmd = &cobra.Command{
 				if err := runUp(ctx, nil); err != nil {
 					return fmt.Errorf("migrate workspace %q: %w", ws.Name, err)
 				}
-				if ws.ExposePort {
-					_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
-					if err := waitForReady(ctx, ws.Port, client); err != nil {
-						return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
-					}
+				_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready...\n")
+				if err := waitForReadiness(ctx, ws.Port, ws.ExposePort, client); err != nil {
+					return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
 				}
 			}
 		}
@@ -326,6 +323,13 @@ const (
 	readyPollTimeout  = 60 * time.Second
 )
 
+func waitForReadiness(ctx context.Context, port int, exposePort bool, dc *docker.Client) error {
+	if exposePort {
+		return waitForReady(ctx, port, dc)
+	}
+	return waitForReadyExec(ctx, port, dc)
+}
+
 func waitForReady(ctx context.Context, port int, dc *docker.Client) error {
 	url := fmt.Sprintf("http://localhost:%d", port)
 
@@ -355,6 +359,33 @@ func waitForReady(ctx context.Context, port int, dc *docker.Client) error {
 				continue
 			}
 			_ = resp.Body.Close()
+			return nil
+		}
+	}
+}
+
+func waitForReadyExec(ctx context.Context, port int, dc *docker.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, readyPollTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(readyPollInterval)
+	defer ticker.Stop()
+
+	probeArgs := []string{"curl", "-sf", fmt.Sprintf("http://localhost:%d", port)}
+
+	for {
+		state, exitCode, err := dc.ContainerState(ctx)
+		if err == nil && state == "exited" {
+			return fmt.Errorf("container exited with code %d before becoming ready", exitCode)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %s waiting for in-container readiness probe", readyPollTimeout)
+		case <-ticker.C:
+			if err := dc.Exec(ctx, probeArgs, nil, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+				continue
+			}
 			return nil
 		}
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -150,6 +150,9 @@ var rootCmd = &cobra.Command{
 
 		mode := resolveFromFlags(cmd, cfg)
 		if !ws.ExposePort && mode != config.ModeExec {
+			if remoteFlag {
+				return fmt.Errorf("remote mode is unavailable for workspace %q because the port is not exposed", ws.Name)
+			}
 			mode = config.ModeExec
 		}
 		attachCtx, stop, err := startAttachWatch(ctx, client, ws.Name)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -121,9 +121,11 @@ var rootCmd = &cobra.Command{
 			if err := runUp(ctx, nil); err != nil {
 				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 			}
-			_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
-			if err := waitForReady(ctx, ws.Port, client); err != nil {
-				return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
+			if ws.ExposePort {
+				_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
+				if err := waitForReady(ctx, ws.Port, client); err != nil {
+					return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
+				}
 			}
 		} else {
 			interactive := term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // G115: uintptr→int is safe for file descriptors
@@ -137,14 +139,19 @@ var rootCmd = &cobra.Command{
 				if err := runUp(ctx, nil); err != nil {
 					return fmt.Errorf("migrate workspace %q: %w", ws.Name, err)
 				}
-				_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
-				if err := waitForReady(ctx, ws.Port, client); err != nil {
-					return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
+				if ws.ExposePort {
+					_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready on port %d...\n", ws.Port)
+					if err := waitForReady(ctx, ws.Port, client); err != nil {
+						return fmt.Errorf("wait for workspace %q readiness: %w", ws.Name, err)
+					}
 				}
 			}
 		}
 
 		mode := resolveFromFlags(cmd, cfg)
+		if !ws.ExposePort && mode != config.ModeExec {
+			mode = config.ModeExec
+		}
 		attachCtx, stop, err := startAttachWatch(ctx, client, ws.Name)
 		if err != nil {
 			return err

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -74,7 +74,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Workspace: %s\n", ws.Name)
-	_, _ = color.New(color.FgCyan).Printf("Port:      %d\n", ws.Port)
+	if ws.ExposePort {
+		_, _ = color.New(color.FgCyan).Printf("Port:      %d\n", ws.Port)
+	} else {
+		_, _ = color.New(color.FgCyan).Printf("Port:      not exposed (exec-only)\n")
+	}
 
 	// Peek at password source without generating or persisting (status is read-only).
 	interactive := term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // G115: uintptr→int is safe for file descriptors

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -98,16 +98,22 @@ func runUp(ctx context.Context, args []string) error {
 			return fmt.Errorf("password migration declined for workspace %q", ws.Name)
 		}
 	} else if running {
-		_, _ = color.New(color.FgYellow).Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
+		if ws.ExposePort {
+			_, _ = color.New(color.FgYellow).Printf("Workspace %s is already running on port %d\n", ws.Name, ws.Port)
+		} else {
+			_, _ = color.New(color.FgYellow).Printf("Workspace %s is already running (exec-only, port not exposed)\n", ws.Name)
+		}
 		return nil
 	}
 
-	runningPorts, err := docker.RunningWorkspacePorts(ctx)
-	if err != nil {
-		return fmt.Errorf("check running workspace ports: %w", err)
-	}
-	if err := checkPortConflict(runningPorts, ws.Name, ws.Port); err != nil {
-		return err
+	if ws.ExposePort {
+		runningPorts, err := docker.RunningWorkspacePorts(ctx)
+		if err != nil {
+			return fmt.Errorf("check running workspace ports: %w", err)
+		}
+		if err := checkPortConflict(runningPorts, ws.Name, ws.Port); err != nil {
+			return err
+		}
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Resolving image for workspace %s...\n", ws.Name)
@@ -170,7 +176,11 @@ func runUp(ctx context.Context, args []string) error {
 		return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 	}
 
-	_, _ = color.New(color.FgGreen).Printf("Workspace %s started on port %d\n", ws.Name, ws.Port)
+	if ws.ExposePort {
+		_, _ = color.New(color.FgGreen).Printf("Workspace %s started on port %d\n", ws.Name, ws.Port)
+	} else {
+		_, _ = color.New(color.FgGreen).Printf("Workspace %s started (exec-only, port not exposed)\n", ws.Name)
+	}
 	return nil
 }
 

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -156,6 +156,7 @@ func runUp(ctx context.Context, args []string) error {
 		Memory:           ws.Memory,
 		UseDataVolume:    !compose.MountsContainTarget(ws.Mounts, "/home/agent/.local/share/opencode"),
 		UseCacheVolume:   !compose.MountsContainTarget(ws.Mounts, "/home/agent/.cache"),
+		ExposePort:       ws.ExposePort,
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Generating compose configuration...\n")

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -27,6 +27,7 @@ type ComposeParams struct {
 	Memory           string
 	UseDataVolume    bool
 	UseCacheVolume   bool
+	ExposePort       bool
 }
 
 func GenerateCompose(params ComposeParams) ([]byte, error) {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -20,6 +20,7 @@ func TestGenerateComposeSinglePath(t *testing.T) {
 		Memory:         "4g",
 		UseDataVolume:  true,
 		UseCacheVolume: true,
+		ExposePort:     true,
 	}
 
 	out, err := GenerateCompose(params)
@@ -133,6 +134,7 @@ func TestWriteComposeFileHappyPath(t *testing.T) {
 		Env: nil,
 		CPU:              2.0,
 		Memory:           "4g",
+		ExposePort:       true,
 	}
 
 	destPath := filepath.Join(t.TempDir(), "docker-compose.yml")
@@ -187,6 +189,34 @@ func TestWriteComposeFileErrorPath(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "write compose file") {
 		t.Fatalf("expected error message to contain 'write compose file', got: %v", err)
+	}
+}
+
+func TestGenerateComposeExposePortFalseOmitsPorts(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "noport",
+		Port:          4111,
+		Image:         "ghcr.io/seznam/jailoc:test",
+		Paths:         []string{"/tmp/workspace"},
+		CPU:           2.0,
+		Memory:        "4g",
+		ExposePort:    false,
+	}
+
+	out, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose returned error: %v", err)
+	}
+
+	rendered := string(out)
+
+	if strings.Contains(rendered, "ports:") {
+		t.Fatal("expected no ports: section when ExposePort is false")
+	}
+	if strings.Contains(rendered, "127.0.0.1") {
+		t.Fatal("expected no 127.0.0.1 binding when ExposePort is false")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ const (
 # allowed_networks = ["10.0.0.0/8"]
 # ssh_auth_sock = false
 # git_config = true
+# expose_port = true
 # cpu = 2.0
 # memory = "4g"
 
@@ -51,6 +52,7 @@ paths = []
 # dockerfile = ""
 # ssh_auth_sock = false
 # git_config = true
+# expose_port = true
 # cpu = 2.0
 # memory = "4g"
 `

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ type Defaults struct {
 	GitConfig       *bool    `toml:"git_config"`
 	CPU             *float64 `toml:"cpu"`
 	Memory          *string  `toml:"memory"`
+	ExposePort      *bool    `toml:"expose_port"`
 }
 
 type Workspace struct {
@@ -183,6 +184,7 @@ type Workspace struct {
 	GitConfig       *bool    `toml:"git_config"`
 	CPU             *float64 `toml:"cpu"`
 	Memory          *string  `toml:"memory"`
+	ExposePort      *bool    `toml:"expose_port"`
 }
 
 func ConfigDir() string {

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -4,8 +4,10 @@ name: jailoc-{{.WorkspaceName}}
 services:
   opencode:
     image: {{.Image}}
+{{- if .ExposePort}}
     ports:
       - "127.0.0.1:{{.Port}}:4096"
+{{- end}}
     volumes:
 {{- range .Paths}}
       - {{.}}:{{.}}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -35,6 +35,7 @@ type Resolved struct {
 	GitConfig       bool
 	CPU             float64
 	Memory          string
+	ExposePort      bool
 }
 
 func Resolve(cfg *config.Config, name string) (*Resolved, error) {
@@ -115,6 +116,7 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 		GitConfig:       boolPtrWithDefault(cfg.Defaults.GitConfig, ws.GitConfig, true),
 		CPU:             floatWithDefault(cfg.Defaults.CPU, ws.CPU, 2.0),
 		Memory:          stringWithDefault(cfg.Defaults.Memory, ws.Memory, "4g"),
+		ExposePort:      boolPtrWithDefault(cfg.Defaults.ExposePort, ws.ExposePort, true),
 	}, nil
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -884,6 +884,46 @@ func TestResolveSSHGitFieldsWorkspaceOverride(t *testing.T) {
 	}
 }
 
+func TestResolveExposePortDefaultsTrue(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Workspaces: map[string]config.Workspace{
+			"test": {Paths: []string{"/tmp"}},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "test")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if !resolved.ExposePort {
+		t.Fatal("expected ExposePort = true by default")
+	}
+}
+
+func TestResolveExposePortWorkspaceOverride(t *testing.T) {
+	t.Parallel()
+
+	boolFalse := false
+	cfg := &config.Config{
+		Workspaces: map[string]config.Workspace{
+			"test": {
+				Paths:      []string{"/tmp"},
+				ExposePort: &boolFalse,
+			},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "test")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if resolved.ExposePort {
+		t.Fatal("expected ExposePort = false when workspace sets it false")
+	}
+}
+
 func TestResolveImagePropagation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -924,6 +924,54 @@ func TestResolveExposePortWorkspaceOverride(t *testing.T) {
 	}
 }
 
+func TestResolveExposePortDefaultsOverride(t *testing.T) {
+	t.Parallel()
+
+	boolFalse := false
+	cfg := &config.Config{
+		Defaults: config.Defaults{
+			ExposePort: &boolFalse,
+		},
+		Workspaces: map[string]config.Workspace{
+			"test": {Paths: []string{"/tmp"}},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "test")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if resolved.ExposePort {
+		t.Fatal("expected ExposePort = false when defaults set it false and workspace leaves it unset")
+	}
+}
+
+func TestResolveExposePortWorkspaceOverridesDefaults(t *testing.T) {
+	t.Parallel()
+
+	boolFalse := false
+	boolTrue := true
+	cfg := &config.Config{
+		Defaults: config.Defaults{
+			ExposePort: &boolFalse,
+		},
+		Workspaces: map[string]config.Workspace{
+			"test": {
+				Paths:      []string{"/tmp"},
+				ExposePort: &boolTrue,
+			},
+		},
+	}
+
+	resolved, err := workspace.Resolve(cfg, "test")
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if !resolved.ExposePort {
+		t.Fatal("expected ExposePort = true when workspace sets it true and defaults set it false")
+	}
+}
+
 func TestResolveImagePropagation(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add `expose_port` workspace-level config (`*bool`, default `true`) to control whether the opencode container port is published to the host
- When `false`, omit `ports:` from generated compose and show "not exposed (exec-only)" in `jailoc status`
- `jailoc attach` in exec mode still works regardless of the setting

Closes #87