### PR TITLE
feat(status): show container resource consumption stats

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -135,10 +135,14 @@ func printContainerStats(s docker.ContainerStats) {
 	value := color.New(color.FgWhite)
 
 	_, _ = label.Printf("CPU:       ")
-	_, _ = value.Printf("%.1f%%\n", s.CPUPercent)
+	if s.CPULimit > 0 {
+		_, _ = value.Printf("%.1f%% (limit: %.1f cores)\n", s.CPUPercent, s.CPULimit)
+	} else {
+		_, _ = value.Printf("%.1f%%\n", s.CPUPercent)
+	}
 
 	_, _ = label.Printf("Memory:    ")
-	_, _ = value.Printf("%s / %s\n", docker.FormatBytes(s.MemUsage), docker.FormatBytes(s.MemLimit))
+	_, _ = value.Printf("%s / %s (%.1f%%)\n", docker.FormatBytes(s.MemUsage), docker.FormatBytes(s.MemLimit), s.MemPercent)
 
 	_, _ = label.Printf("PIDs:      ")
 	if s.PIDsLimit > 0 {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -117,7 +117,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			printContainerStats(stats)
 		} else {
 			_, _ = color.New(color.FgCyan).Printf("Stats:     ")
-			_, _ = color.New(color.FgYellow).Printf("unavailable\n")
+			_, _ = color.New(color.FgYellow).Printf("unavailable (%v)\n", statsErr)
 		}
 	case "exited":
 		_, _ = color.New(color.FgCyan).Printf("Status:    ")

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -111,6 +111,11 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			_, _ = color.New(color.FgCyan).Printf("Status:    ")
 			_, _ = color.New(color.FgGreen).Printf("running\n")
 		}
+
+		stats, statsErr := client.ContainerStats(ctx)
+		if statsErr == nil {
+			printContainerStats(stats)
+		}
 	case "exited":
 		_, _ = color.New(color.FgCyan).Printf("Status:    ")
 		_, _ = color.New(color.FgRed).Printf("exited (code %d)\n", exitCode)
@@ -120,6 +125,33 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func printContainerStats(s docker.ContainerStats) {
+	label := color.New(color.FgCyan)
+	value := color.New(color.FgWhite)
+
+	_, _ = label.Printf("CPU:       ")
+	_, _ = value.Printf("%.1f%%\n", s.CPUPercent)
+
+	_, _ = label.Printf("Memory:    ")
+	_, _ = value.Printf("%s / %s\n", docker.FormatBytes(s.MemUsage), docker.FormatBytes(s.MemLimit))
+
+	_, _ = label.Printf("PIDs:      ")
+	if s.PIdsLimit > 0 {
+		_, _ = value.Printf("%d / %d\n", s.PIDsCurrent, s.PIdsLimit)
+	} else {
+		_, _ = value.Printf("%d / unlimited\n", s.PIDsCurrent)
+	}
+
+	_, _ = label.Printf("Net I/O:   ")
+	_, _ = value.Printf("%s rx / %s tx\n", docker.FormatBytes(s.NetRx), docker.FormatBytes(s.NetTx))
+
+	_, _ = label.Printf("Block I/O: ")
+	_, _ = value.Printf("%s read / %s write\n", docker.FormatBytes(s.BlockRead), docker.FormatBytes(s.BlockWrite))
+
+	_, _ = label.Printf("Uptime:    ")
+	_, _ = value.Printf("%s\n", docker.FormatUptime(s.Uptime))
 }
 
 func init() {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -115,6 +115,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		stats, statsErr := client.ContainerStats(ctx)
 		if statsErr == nil {
 			printContainerStats(stats)
+		} else {
+			_, _ = color.New(color.FgCyan).Printf("Stats:     ")
+			_, _ = color.New(color.FgYellow).Printf("unavailable\n")
 		}
 	case "exited":
 		_, _ = color.New(color.FgCyan).Printf("Status:    ")
@@ -138,8 +141,8 @@ func printContainerStats(s docker.ContainerStats) {
 	_, _ = value.Printf("%s / %s\n", docker.FormatBytes(s.MemUsage), docker.FormatBytes(s.MemLimit))
 
 	_, _ = label.Printf("PIDs:      ")
-	if s.PIdsLimit > 0 {
-		_, _ = value.Printf("%d / %d\n", s.PIDsCurrent, s.PIdsLimit)
+	if s.PIDsLimit > 0 {
+		_, _ = value.Printf("%d / %d\n", s.PIDsCurrent, s.PIDsLimit)
 	} else {
 		_, _ = value.Printf("%d / unlimited\n", s.PIDsCurrent)
 	}

--- a/internal/docker/stats.go
+++ b/internal/docker/stats.go
@@ -1,0 +1,171 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	dcontainer "github.com/docker/docker/api/types/container"
+	dockerclient "github.com/docker/docker/client"
+)
+
+// ContainerStats holds parsed resource consumption metrics for a container.
+type ContainerStats struct {
+	CPUPercent float64
+	MemUsage   uint64
+	MemLimit   uint64
+	PIDsCurrent uint64
+	PIdsLimit   uint64
+	NetRx      uint64
+	NetTx      uint64
+	BlockRead  uint64
+	BlockWrite uint64
+	Uptime     time.Duration
+}
+
+// ContainerStats fetches a one-shot stats snapshot for the opencode container.
+func (c *Client) ContainerStats(ctx context.Context) (ContainerStats, error) {
+	containerID, err := c.CurrentContainerID(ctx)
+	if err != nil {
+		return ContainerStats{}, fmt.Errorf("get container ID for stats: %w", err)
+	}
+	if containerID == "" {
+		return ContainerStats{}, fmt.Errorf("no running opencode container")
+	}
+
+	engineCli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		return ContainerStats{}, fmt.Errorf("create docker engine client for stats: %w", err)
+	}
+	defer func() { _ = engineCli.Close() }()
+
+	resp, err := engineCli.ContainerStatsOneShot(ctx, containerID)
+	if err != nil {
+		return ContainerStats{}, fmt.Errorf("fetch container stats: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var v dcontainer.StatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return ContainerStats{}, fmt.Errorf("decode container stats: %w", err)
+	}
+
+	inspect, err := engineCli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return ContainerStats{}, fmt.Errorf("inspect container for uptime: %w", err)
+	}
+
+	var uptime time.Duration
+	if startedAt, parseErr := time.Parse(time.RFC3339Nano, inspect.State.StartedAt); parseErr == nil {
+		uptime = time.Since(startedAt)
+	}
+
+	return ContainerStats{
+		CPUPercent:  calcCPUPercent(v.PreCPUStats, v.CPUStats),
+		MemUsage:    calcMemUsage(v.MemoryStats),
+		MemLimit:    v.MemoryStats.Limit,
+		PIDsCurrent: v.PidsStats.Current,
+		PIdsLimit:   v.PidsStats.Limit,
+		NetRx:       sumNetRx(v.Networks),
+		NetTx:       sumNetTx(v.Networks),
+		BlockRead:   calcBlockRead(v.BlkioStats),
+		BlockWrite:  calcBlockWrite(v.BlkioStats),
+		Uptime:      uptime,
+	}, nil
+}
+
+func calcCPUPercent(pre, cur dcontainer.CPUStats) float64 {
+	cpuDelta := float64(cur.CPUUsage.TotalUsage) - float64(pre.CPUUsage.TotalUsage)
+	systemDelta := float64(cur.SystemUsage) - float64(pre.SystemUsage)
+	if systemDelta <= 0 || cpuDelta < 0 {
+		return 0
+	}
+	return (cpuDelta / systemDelta) * float64(cur.OnlineCPUs) * 100.0
+}
+
+func calcMemUsage(m dcontainer.MemoryStats) uint64 {
+	// cgroup v2 uses "inactive_file", v1 uses "total_inactive_file".
+	if cache, ok := m.Stats["inactive_file"]; ok && cache < m.Usage {
+		return m.Usage - cache
+	}
+	if cache, ok := m.Stats["total_inactive_file"]; ok && cache < m.Usage {
+		return m.Usage - cache
+	}
+	return m.Usage
+}
+
+func sumNetRx(networks map[string]dcontainer.NetworkStats) uint64 {
+	var total uint64
+	for _, n := range networks {
+		total += n.RxBytes
+	}
+	return total
+}
+
+func sumNetTx(networks map[string]dcontainer.NetworkStats) uint64 {
+	var total uint64
+	for _, n := range networks {
+		total += n.TxBytes
+	}
+	return total
+}
+
+func calcBlockRead(blkio dcontainer.BlkioStats) uint64 {
+	var total uint64
+	for _, entry := range blkio.IoServiceBytesRecursive {
+		if len(entry.Op) > 0 && (entry.Op[0] == 'r' || entry.Op[0] == 'R') {
+			total += entry.Value
+		}
+	}
+	return total
+}
+
+func calcBlockWrite(blkio dcontainer.BlkioStats) uint64 {
+	var total uint64
+	for _, entry := range blkio.IoServiceBytesRecursive {
+		if len(entry.Op) > 0 && (entry.Op[0] == 'w' || entry.Op[0] == 'W') {
+			total += entry.Value
+		}
+	}
+	return total
+}
+
+// FormatBytes formats a byte count into a human-readable string (e.g. "1.5 GiB").
+func FormatBytes(b uint64) string {
+	const (
+		kib = 1024
+		mib = 1024 * kib
+		gib = 1024 * mib
+	)
+	switch {
+	case b >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(gib))
+	case b >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(b)/float64(mib))
+	case b >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(b)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}
+
+// FormatUptime formats a duration into a human-readable uptime string.
+func FormatUptime(d time.Duration) string {
+	d = d.Truncate(time.Second)
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	minutes := int(d.Minutes()) % 60
+	seconds := int(d.Seconds()) % 60
+
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh %dm", days, hours, minutes)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm %ds", hours, minutes, seconds)
+	case minutes > 0:
+		return fmt.Sprintf("%dm %ds", minutes, seconds)
+	default:
+		return fmt.Sprintf("%ds", seconds)
+	}
+}

--- a/internal/docker/stats.go
+++ b/internal/docker/stats.go
@@ -13,8 +13,10 @@ import (
 // ContainerStats holds parsed resource consumption metrics for a container.
 type ContainerStats struct {
 	CPUPercent float64
+	CPULimit   float64 // CPU core limit (0 = unlimited)
 	MemUsage   uint64
 	MemLimit   uint64
+	MemPercent float64
 	PIDsCurrent uint64
 	PIDsLimit   uint64
 	NetRx      uint64
@@ -61,10 +63,19 @@ func (c *Client) ContainerStats(ctx context.Context) (ContainerStats, error) {
 		uptime = time.Since(startedAt)
 	}
 
+	memUsage := calcMemUsage(v.MemoryStats)
+	memLimit := v.MemoryStats.Limit
+	var memPercent float64
+	if memLimit > 0 {
+		memPercent = float64(memUsage) / float64(memLimit) * 100.0
+	}
+
 	return ContainerStats{
 		CPUPercent:  calcCPUPercent(v.PreCPUStats, v.CPUStats),
-		MemUsage:    calcMemUsage(v.MemoryStats),
-		MemLimit:    v.MemoryStats.Limit,
+		CPULimit:    calcCPULimit(inspect.HostConfig.Resources),
+		MemUsage:    memUsage,
+		MemLimit:    memLimit,
+		MemPercent:  memPercent,
 		PIDsCurrent: v.PidsStats.Current,
 		PIDsLimit:   v.PidsStats.Limit,
 		NetRx:       sumNetRx(v.Networks),
@@ -92,6 +103,16 @@ func calcCPUPercent(pre, cur dcontainer.CPUStats) float64 {
 	}
 
 	return (cpuDelta / systemDelta) * float64(onlineCPUs) * 100.0
+}
+
+func calcCPULimit(r dcontainer.Resources) float64 {
+	if r.NanoCPUs > 0 {
+		return float64(r.NanoCPUs) / 1e9
+	}
+	if r.CPUQuota > 0 && r.CPUPeriod > 0 {
+		return float64(r.CPUQuota) / float64(r.CPUPeriod)
+	}
+	return 0
 }
 
 func calcMemUsage(m dcontainer.MemoryStats) uint64 {

--- a/internal/docker/stats.go
+++ b/internal/docker/stats.go
@@ -81,7 +81,17 @@ func calcCPUPercent(pre, cur dcontainer.CPUStats) float64 {
 	if systemDelta <= 0 || cpuDelta < 0 {
 		return 0
 	}
-	return (cpuDelta / systemDelta) * float64(cur.OnlineCPUs) * 100.0
+	onlineCPUs := cur.OnlineCPUs
+	if onlineCPUs == 0 {
+		n := len(cur.CPUUsage.PercpuUsage)
+		if n > 0 {
+			onlineCPUs = uint32(n) //nolint:gosec // PercpuUsage length is bounded by physical CPU count
+		} else {
+			onlineCPUs = 1
+		}
+	}
+
+	return (cpuDelta / systemDelta) * float64(onlineCPUs) * 100.0
 }
 
 func calcMemUsage(m dcontainer.MemoryStats) uint64 {

--- a/internal/docker/stats.go
+++ b/internal/docker/stats.go
@@ -36,7 +36,7 @@ func (c *Client) ContainerStats(ctx context.Context) (ContainerStats, error) {
 
 	engineCli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
 	if err != nil {
-		return ContainerStats{}, fmt.Errorf("create docker engine client for stats: %w", err)
+		return ContainerStats{}, fmt.Errorf("create Docker Engine client for stats: %w", err)
 	}
 	defer func() { _ = engineCli.Close() }()
 
@@ -86,10 +86,10 @@ func calcCPUPercent(pre, cur dcontainer.CPUStats) float64 {
 
 func calcMemUsage(m dcontainer.MemoryStats) uint64 {
 	// cgroup v2 uses "inactive_file", v1 uses "total_inactive_file".
-	if cache, ok := m.Stats["inactive_file"]; ok && cache < m.Usage {
+	if cache, ok := m.Stats["inactive_file"]; ok && cache <= m.Usage {
 		return m.Usage - cache
 	}
-	if cache, ok := m.Stats["total_inactive_file"]; ok && cache < m.Usage {
+	if cache, ok := m.Stats["total_inactive_file"]; ok && cache <= m.Usage {
 		return m.Usage - cache
 	}
 	return m.Usage

--- a/internal/docker/stats.go
+++ b/internal/docker/stats.go
@@ -16,7 +16,7 @@ type ContainerStats struct {
 	MemUsage   uint64
 	MemLimit   uint64
 	PIDsCurrent uint64
-	PIdsLimit   uint64
+	PIDsLimit   uint64
 	NetRx      uint64
 	NetTx      uint64
 	BlockRead  uint64
@@ -66,7 +66,7 @@ func (c *Client) ContainerStats(ctx context.Context) (ContainerStats, error) {
 		MemUsage:    calcMemUsage(v.MemoryStats),
 		MemLimit:    v.MemoryStats.Limit,
 		PIDsCurrent: v.PidsStats.Current,
-		PIdsLimit:   v.PidsStats.Limit,
+		PIDsLimit:   v.PidsStats.Limit,
 		NetRx:       sumNetRx(v.Networks),
 		NetTx:       sumNetTx(v.Networks),
 		BlockRead:   calcBlockRead(v.BlkioStats),

--- a/internal/docker/stats_test.go
+++ b/internal/docker/stats_test.go
@@ -57,12 +57,14 @@ func TestCalcCPUPercent(t *testing.T) {
 		},
 	}
 
+	const epsilon = 1e-9
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			got := calcCPUPercent(tc.pre, tc.cur)
-			if got != tc.want {
+			if diff := got - tc.want; diff > epsilon || diff < -epsilon {
 				t.Fatalf("got %.2f, want %.2f", got, tc.want)
 			}
 		})

--- a/internal/docker/stats_test.go
+++ b/internal/docker/stats_test.go
@@ -55,6 +55,35 @@ func TestCalcCPUPercent(t *testing.T) {
 			},
 			want: 0,
 		},
+		{
+			name: "OnlineCPUs zero falls back to PercpuUsage length",
+			pre: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 100_000_000},
+				SystemUsage: 1_000_000_000,
+			},
+			cur: dcontainer.CPUStats{
+				CPUUsage: dcontainer.CPUUsage{
+					TotalUsage:  200_000_000,
+					PercpuUsage: []uint64{0, 0, 0, 0},
+				},
+				SystemUsage: 2_000_000_000,
+				OnlineCPUs:  0,
+			},
+			want: 40.0,
+		},
+		{
+			name: "OnlineCPUs zero and empty PercpuUsage falls back to 1",
+			pre: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 100_000_000},
+				SystemUsage: 1_000_000_000,
+			},
+			cur: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 200_000_000},
+				SystemUsage: 2_000_000_000,
+				OnlineCPUs:  0,
+			},
+			want: 10.0,
+		},
 	}
 
 	const epsilon = 1e-9

--- a/internal/docker/stats_test.go
+++ b/internal/docker/stats_test.go
@@ -1,0 +1,237 @@
+package docker
+
+import (
+	"testing"
+	"time"
+
+	dcontainer "github.com/docker/docker/api/types/container"
+)
+
+func TestCalcCPUPercent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pre  dcontainer.CPUStats
+		cur  dcontainer.CPUStats
+		want float64
+	}{
+		{
+			name: "normal usage with 4 CPUs",
+			pre: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 100_000_000},
+				SystemUsage: 1_000_000_000,
+			},
+			cur: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 200_000_000},
+				SystemUsage: 2_000_000_000,
+				OnlineCPUs:  4,
+			},
+			want: 40.0,
+		},
+		{
+			name: "zero system delta returns zero",
+			pre: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 100},
+				SystemUsage: 500,
+			},
+			cur: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 200},
+				SystemUsage: 500,
+				OnlineCPUs:  2,
+			},
+			want: 0,
+		},
+		{
+			name: "zero CPU delta returns zero",
+			pre: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 100},
+				SystemUsage: 500,
+			},
+			cur: dcontainer.CPUStats{
+				CPUUsage:    dcontainer.CPUUsage{TotalUsage: 100},
+				SystemUsage: 1000,
+				OnlineCPUs:  1,
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := calcCPUPercent(tc.pre, tc.cur)
+			if got != tc.want {
+				t.Fatalf("got %.2f, want %.2f", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCalcMemUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mem  dcontainer.MemoryStats
+		want uint64
+	}{
+		{
+			name: "cgroup v2 subtracts inactive_file",
+			mem: dcontainer.MemoryStats{
+				Usage: 1000,
+				Stats: map[string]uint64{"inactive_file": 200},
+			},
+			want: 800,
+		},
+		{
+			name: "cgroup v1 subtracts total_inactive_file",
+			mem: dcontainer.MemoryStats{
+				Usage: 1000,
+				Stats: map[string]uint64{"total_inactive_file": 300},
+			},
+			want: 700,
+		},
+		{
+			name: "no cache stats returns raw usage",
+			mem: dcontainer.MemoryStats{
+				Usage: 500,
+				Stats: map[string]uint64{},
+			},
+			want: 500,
+		},
+		{
+			name: "cache exceeds usage returns raw usage",
+			mem: dcontainer.MemoryStats{
+				Usage: 100,
+				Stats: map[string]uint64{"inactive_file": 200},
+			},
+			want: 100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := calcMemUsage(tc.mem)
+			if got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSumNetRxTx(t *testing.T) {
+	t.Parallel()
+
+	networks := map[string]dcontainer.NetworkStats{
+		"eth0": {RxBytes: 100, TxBytes: 200},
+		"eth1": {RxBytes: 300, TxBytes: 400},
+	}
+
+	if got := sumNetRx(networks); got != 400 {
+		t.Fatalf("sumNetRx: got %d, want 400", got)
+	}
+	if got := sumNetTx(networks); got != 600 {
+		t.Fatalf("sumNetTx: got %d, want 600", got)
+	}
+}
+
+func TestSumNetEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := sumNetRx(nil); got != 0 {
+		t.Fatalf("sumNetRx(nil): got %d, want 0", got)
+	}
+	if got := sumNetTx(nil); got != 0 {
+		t.Fatalf("sumNetTx(nil): got %d, want 0", got)
+	}
+}
+
+func TestCalcBlockReadWrite(t *testing.T) {
+	t.Parallel()
+
+	blkio := dcontainer.BlkioStats{
+		IoServiceBytesRecursive: []dcontainer.BlkioStatEntry{
+			{Op: "read", Value: 1024},
+			{Op: "Read", Value: 2048},
+			{Op: "write", Value: 512},
+			{Op: "Write", Value: 256},
+			{Op: "sync", Value: 999},
+		},
+	}
+
+	if got := calcBlockRead(blkio); got != 3072 {
+		t.Fatalf("calcBlockRead: got %d, want 3072", got)
+	}
+	if got := calcBlockWrite(blkio); got != 768 {
+		t.Fatalf("calcBlockWrite: got %d, want 768", got)
+	}
+}
+
+func TestCalcBlockEmpty(t *testing.T) {
+	t.Parallel()
+
+	blkio := dcontainer.BlkioStats{}
+	if got := calcBlockRead(blkio); got != 0 {
+		t.Fatalf("calcBlockRead(empty): got %d, want 0", got)
+	}
+	if got := calcBlockWrite(blkio); got != 0 {
+		t.Fatalf("calcBlockWrite(empty): got %d, want 0", got)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input uint64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1048576, "1.0 MiB"},
+		{1073741824, "1.0 GiB"},
+		{1610612736, "1.5 GiB"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+
+			got := FormatBytes(tc.input)
+			if got != tc.want {
+				t.Fatalf("FormatBytes(%d): got %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatUptime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input time.Duration
+		want  string
+	}{
+		{5 * time.Second, "5s"},
+		{90 * time.Second, "1m 30s"},
+		{3661 * time.Second, "1h 1m 1s"},
+		{90061 * time.Second, "1d 1h 1m"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+
+			got := FormatUptime(tc.input)
+			if got != tc.want {
+				t.Fatalf("FormatUptime(%v): got %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/docker/stats_test.go
+++ b/internal/docker/stats_test.go
@@ -214,6 +214,50 @@ func TestCalcBlockEmpty(t *testing.T) {
 	}
 }
 
+func TestCalcCPULimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		res  dcontainer.Resources
+		want float64
+	}{
+		{
+			name: "NanoCPUs set to 2 cores",
+			res:  dcontainer.Resources{NanoCPUs: 2_000_000_000},
+			want: 2.0,
+		},
+		{
+			name: "CPUQuota and CPUPeriod set to 0.5 cores",
+			res:  dcontainer.Resources{CPUQuota: 50000, CPUPeriod: 100000},
+			want: 0.5,
+		},
+		{
+			name: "NanoCPUs takes precedence over quota/period",
+			res:  dcontainer.Resources{NanoCPUs: 1_000_000_000, CPUQuota: 50000, CPUPeriod: 100000},
+			want: 1.0,
+		},
+		{
+			name: "no limits returns zero",
+			res:  dcontainer.Resources{},
+			want: 0,
+		},
+	}
+
+	const epsilon = 1e-9
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := calcCPULimit(tc.res)
+			if diff := got - tc.want; diff > epsilon || diff < -epsilon {
+				t.Fatalf("got %.2f, want %.2f", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFormatBytes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add live resource stats (CPU%, memory, PIDs, net I/O, block I/O, uptime) to `jailoc status` output when container is running
- Uses Docker Engine SDK `ContainerStatsOneShot` for one-shot stats collection
- Handles cgroup v1/v2 memory calculation differences

Closes #90