### PR TITLE
docs(custom-images): add base image requirements section

### DIFF
--- a/docs/how-to/custom-images.md
+++ b/docs/how-to/custom-images.md
@@ -8,20 +8,20 @@ By default, jailoc builds a base image from the Dockerfile embedded in the binar
 
 Any image used directly (`image` or `defaults.image`) or built from a custom Dockerfile (`[base].dockerfile`) must provide the components below. Overlay Dockerfiles that extend the default jailoc base (`ARG BASE` / `FROM ${BASE}`) inherit all of these automatically.
 
-| Component | Debian/Ubuntu package | Role |
+| Component | Source (Debian/Ubuntu) | Role |
 |---|---|---|
 | `bash` | `bash` | Entrypoint interpreter |
 | `iptables` or `iptables-legacy` | `iptables` | Network isolation setup |
 | `setpriv` | `util-linux` | Privilege drop from root to UID 1000 |
 | `getent` | `libc-bin` | Hostname resolution in entrypoint |
 | `awk` | `gawk` or `mawk` | Route table parsing in entrypoint |
-| `opencode` | `opencode-ai` (npm) | Agent runtime (`opencode serve`) |
+| `opencode` | any method providing the binary on `PATH` | Agent runtime (`opencode serve`) |
 
 The image must also have:
 
 - A user with **UID 1000** and home directory `/home/agent`
 - Directories `/home/agent/.local` and `/home/agent/.cache`
-- `PATH` including `/home/agent/.local/bin`
+- `PATH` including `/home/agent/.local/bin` and `/home/agent/.opencode/bin`
 
 !!! warning
     A plain OS image like `ubuntu:24.04` does not satisfy these requirements. The container will fail to start without iptables, setpriv, the UID 1000 user, and opencode on PATH.

--- a/docs/how-to/custom-images.md
+++ b/docs/how-to/custom-images.md
@@ -4,6 +4,30 @@ By default, jailoc builds a base image from the Dockerfile embedded in the binar
 
 ---
 
+## Base image requirements
+
+Any image used directly (`image` or `defaults.image`) or built from a custom Dockerfile (`[base].dockerfile`) must provide the components below. Overlay Dockerfiles that extend the default jailoc base (`ARG BASE` / `FROM ${BASE}`) inherit all of these automatically.
+
+| Component | Debian/Ubuntu package | Role |
+|---|---|---|
+| `bash` | `bash` | Entrypoint interpreter |
+| `iptables` or `iptables-legacy` | `iptables` | Network isolation setup |
+| `setpriv` | `util-linux` | Privilege drop from root to UID 1000 |
+| `getent` | `libc-bin` | Hostname resolution in entrypoint |
+| `awk` | `gawk` or `mawk` | Route table parsing in entrypoint |
+| `opencode` | `opencode-ai` (npm) | Agent runtime (`opencode serve`) |
+
+The image must also have:
+
+- A user with **UID 1000** and home directory `/home/agent`
+- Directories `/home/agent/.local` and `/home/agent/.cache`
+- `PATH` including `/home/agent/.local/bin`
+
+!!! warning
+    A plain OS image like `ubuntu:24.04` does not satisfy these requirements. The container will fail to start without iptables, setpriv, the UID 1000 user, and opencode on PATH.
+
+---
+
 ## Use a pre-built image directly
 
 Set `image` in the workspace block to skip all build steps. Compose pulls the image from its registry at container startup.
@@ -28,7 +52,7 @@ Set `image` in `[defaults]` to use a pre-built image as the starting point for a
 image = "myregistry.example.com/myteam/opencode-base:v1.2.3"
 ```
 
-The image must contain OpenCode and the required agent tooling (iptables, setpriv). A plain OS image like `ubuntu:22.04` cannot be used here — the container would fail to start. When `defaults.image` is not set, jailoc builds from its embedded Dockerfile automatically.
+The image must meet the [base image requirements](#base-image-requirements). When `defaults.image` is not set, jailoc builds from its embedded Dockerfile automatically.
 
 With this set, a workspace that adds its own `dockerfile` builds on top of the specified image:
 
@@ -62,6 +86,8 @@ dockerfile = "https://git.example.com/team/dockerfiles/-/raw/main/opencode.Docke
 
 !!! warning
     If the file doesn't exist, the download fails (or exceeds 1 MiB), or the build fails, jailoc aborts. There is no fallback to the embedded image.
+
+The resulting image must meet the [base image requirements](#base-image-requirements).
 
 ---
 

--- a/docs/reference/overlay-compatibility.md
+++ b/docs/reference/overlay-compatibility.md
@@ -56,5 +56,6 @@ The table below lists overlay actions that affect runtime behaviour. Severity le
 ## Related pages
 
 - [Custom images](../how-to/custom-images.md) — how to build and configure overlay Dockerfiles
+- [Base image requirements](../how-to/custom-images.md#base-image-requirements) — components a custom base image must provide
 - [Container architecture](../explanation/container-architecture.md) — entrypoint phases, volume layout, and the DinD sidecar
 - [Image resolution](image-resolution.md) — the two-tier model that resolves base and overlay images


### PR DESCRIPTION
## Summary

- Add "Base image requirements" section to `docs/how-to/custom-images.md` listing all components a custom base image must provide (bash, iptables, setpriv, getent, awk, opencode, UID 1000 user, PATH)
- Replace the terse one-liner in "Set a default base image" with a cross-reference to the new section
- Add cross-link from `overlay-compatibility.md`

Previously, requirements were only implied through the "What to avoid" framing (don't remove X), which assumes overlay authors start from the jailoc base. Users building a base image from scratch had no positive checklist.