### PR TITLE
fix(docker): forward host proxy env vars as build args

### DIFF
--- a/docs/how-to/custom-images.md
+++ b/docs/how-to/custom-images.md
@@ -215,6 +215,10 @@ RUN curl -fsSL https://github.com/org/tool/releases/download/v1.0/tool-linux-amd
 
 If the tool requires compilation, use a [multi-stage build](#use-multi-stage-builds-for-compiled-tools) instead to keep the final image small.
 
+### Proxy support during builds
+
+If your host environment has proxy variables set (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `FTP_PROXY`, `ALL_PROXY`, and their lowercase variants), jailoc forwards them as build arguments to all image builds — base, preset, and workspace overlay. No `ARG` declarations are needed in the Dockerfile; Docker treats these as [predefined build arguments](https://docs.docker.com/build/building/variables/#proxy-arguments).
+
 ### What to avoid
 
 !!! danger "Fatal: breaks the container entirely"

--- a/docs/reference/image-resolution.md
+++ b/docs/reference/image-resolution.md
@@ -43,7 +43,7 @@ flowchart TD
 
 **Behavior:**
 - The workspace Dockerfile is loaded from the specified source (local path or HTTP URL).
-- An overlay image is built on top of `defaults.image`, passed as the `BASE` build argument.
+- An overlay image is built on top of `defaults.image`, passed as the `BASE` build argument. Host proxy environment variables are forwarded as build arguments automatically.
 - The workspace Dockerfile must begin with:
 
   ```dockerfile
@@ -86,6 +86,8 @@ flowchart TD
 
 After this step, a workspace `dockerfile` (if set) is still applied as an overlay on top of the built base.
 
+**Proxy support:** Host proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `FTP_PROXY`, `ALL_PROXY`, and lowercase variants) are forwarded as build arguments automatically.
+
 **Constraints:**
 - Accepted sources: absolute local paths (`/...`), tilde paths (`~/...`), HTTP(S) URLs.
 - Maximum download size for HTTP sources: 1 MiB. Files exceeding this limit cause a fatal error.
@@ -104,13 +106,15 @@ After this step, a workspace `dockerfile` (if set) is still applied as an overla
 
 This step always succeeds (assuming a functional Docker daemon), as the Dockerfile is bundled with the binary.
 
+**Proxy support:** Host proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `FTP_PROXY`, `ALL_PROXY`, and lowercase variants) are forwarded as build arguments automatically.
+
 After this step, a workspace `dockerfile` (if set) is applied as an overlay on top of the embedded base.
 
 ---
 
 ### Workspace overlay (steps 4 and 5 only)
 
-When the cascade reaches step 4 or 5, a workspace `dockerfile` is applied as an additional layer on top of the resolved base image. Steps 1, 2, and 3 handle the workspace Dockerfile themselves (or bypass it entirely) and do not reach this stage.
+When the cascade reaches step 4 or 5, a workspace `dockerfile` is applied as an additional layer on top of the resolved base image. Steps 1, 2, and 3 handle the workspace Dockerfile themselves (or bypass it entirely) and do not reach this stage. Host proxy environment variables are forwarded as build arguments alongside `BASE`.
 
 ```mermaid
 flowchart TD

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -364,6 +364,28 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 	return embeddedTag, nil
 }
 
+// proxyBuildArgs returns Docker build args for proxy environment variables
+// set in the current process environment. Docker Engine API (unlike Docker CLI)
+// does not forward these automatically — they must be passed explicitly.
+func proxyBuildArgs() map[string]*string {
+	keys := []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+		"FTP_PROXY", "ftp_proxy",
+		"ALL_PROXY", "all_proxy",
+	}
+
+	args := make(map[string]*string)
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			args[k] = &v
+		}
+	}
+
+	return args
+}
+
 func buildEmbeddedImage(ctx context.Context, cli dockerclient.APIClient, tag string) error {
 	tmpDir, err := os.MkdirTemp("", "jailoc-embedded-dockerfile-")
 	if err != nil {
@@ -383,8 +405,9 @@ func buildEmbeddedImage(ctx context.Context, cli dockerclient.APIClient, tag str
 	defer func() { _ = buildCtx.Close() }()
 
 	resp, err := cli.ImageBuild(ctx, buildCtx, build.ImageBuildOptions{
-		Tags:   []string{tag},
-		Remove: true,
+		Tags:      []string{tag},
+		BuildArgs: proxyBuildArgs(),
+		Remove:    true,
 	})
 	if err != nil {
 		return fmt.Errorf("build embedded image in %q: %w", tmpDir, err)
@@ -424,8 +447,9 @@ func buildPresetImage(ctx context.Context, cli dockerclient.APIClient, dockerfil
 	defer func() { _ = buildCtx.Close() }()
 
 	resp, err := cli.ImageBuild(ctx, buildCtx, build.ImageBuildOptions{
-		Tags:   []string{presetTag},
-		Remove: true,
+		Tags:      []string{presetTag},
+		BuildArgs: proxyBuildArgs(),
+		Remove:    true,
 	})
 	if err != nil {
 		return "", fmt.Errorf("build preset image in %q: %w", tmpDir, err)
@@ -492,10 +516,13 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 	defer func() { _ = buildCtx.Close() }()
 
 	baseArg := base
+	overlayBuildArgs := proxyBuildArgs()
+	overlayBuildArgs["BASE"] = &baseArg
+
 	_, _ = color.New(color.FgCyan).Printf("Building workspace overlay image...\n")
 	resp, err := engineCli.ImageBuild(ctx, buildCtx, build.ImageBuildOptions{
 		Tags:       []string{overlayTag},
-		BuildArgs:  map[string]*string{"BASE": &baseArg},
+		BuildArgs:  overlayBuildArgs,
 		Dockerfile: filepath.Base(tmpDockerfilePath),
 		Remove:     true,
 	})

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -333,6 +333,59 @@ func TestBuildOverlayImageDockerfileLoadError(t *testing.T) {
 	}
 }
 
+func TestProxyBuildArgs(t *testing.T) {
+	t.Run("collects set proxy vars", func(t *testing.T) {
+		t.Setenv("HTTP_PROXY", "http://proxy:8080")
+		t.Setenv("HTTPS_PROXY", "http://proxy:8443")
+		t.Setenv("NO_PROXY", "localhost,127.0.0.1")
+
+		got := proxyBuildArgs()
+
+		if v := got["HTTP_PROXY"]; v == nil || *v != "http://proxy:8080" {
+			t.Fatalf("HTTP_PROXY: got %v, want %q", v, "http://proxy:8080")
+		}
+		if v := got["HTTPS_PROXY"]; v == nil || *v != "http://proxy:8443" {
+			t.Fatalf("HTTPS_PROXY: got %v, want %q", v, "http://proxy:8443")
+		}
+		if v := got["NO_PROXY"]; v == nil || *v != "localhost,127.0.0.1" {
+			t.Fatalf("NO_PROXY: got %v, want %q", v, "localhost,127.0.0.1")
+		}
+	})
+
+	t.Run("skips unset vars", func(t *testing.T) {
+		for _, k := range []string{
+			"HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy",
+			"NO_PROXY", "no_proxy", "FTP_PROXY", "ftp_proxy",
+			"ALL_PROXY", "all_proxy",
+		} {
+			t.Setenv(k, "")
+			if err := os.Unsetenv(k); err != nil {
+				t.Fatalf("unsetenv %s: %v", k, err)
+			}
+		}
+
+		got := proxyBuildArgs()
+
+		if len(got) != 0 {
+			t.Fatalf("expected empty map, got %v", got)
+		}
+	})
+
+	t.Run("includes both cases independently", func(t *testing.T) {
+		t.Setenv("http_proxy", "http://lower:3128")
+		t.Setenv("HTTP_PROXY", "http://upper:3128")
+
+		got := proxyBuildArgs()
+
+		if v := got["http_proxy"]; v == nil || *v != "http://lower:3128" {
+			t.Fatalf("http_proxy: got %v, want %q", v, "http://lower:3128")
+		}
+		if v := got["HTTP_PROXY"]; v == nil || *v != "http://upper:3128" {
+			t.Fatalf("HTTP_PROXY: got %v, want %q", v, "http://upper:3128")
+		}
+	})
+}
+
 func TestWorkspacePortsFromContainers(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Forward `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `FTP_PROXY`, `ALL_PROXY` (and lowercase variants) from the host environment as Docker build args in all image builds (embedded, preset, overlay).
- Document proxy passthrough in how-to and reference docs.