### PR TITLE
fix(release): enable force-tag-creation for draft releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,10 @@
   "release-type": "go",
   "include-v-in-tag": true,
   "draft": true,
+  "force-tag-creation": true,
+  "last-release-sha": "26866589ca25db4563ccac0184af534e7d0337c0",
+  "release-search-depth": 150,
+  "commit-search-depth": 300,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

- Enable `force-tag-creation` to create git tags immediately for draft releases — without this, GitHub defers tag creation until a draft release is published, causing release-please to lose track of the previous release
- Add `last-release-sha` pointing to current v1.12.2 to fix the immediate broken state
- Add `release-search-depth` and `commit-search-depth` as safety nets against [googleapis/release-please#2267](https://github.com/googleapis/release-please/issues/2267)

Closes the broken PR #124 that included full project history in the changelog.