### PR TITLE
chore(deps): bump embedded dependencies for CVE coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           go-version: "1.26.x"
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.10.1
+          version: v2.11.4
 
   tui-plugin-sync:
     name: TUI Plugin Sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Run `go build`, `go test ./...`, and `golangci-lint run` inside as usual.
 ## CI/CD
 
 GitHub Actions workflows:
-- **CI** (`.github/workflows/ci.yml`): runs on push/PR to master — `go build`, `go test`, `go vet`, and golangci-lint v2.10.1 (gosec, staticcheck, gocritic)
+- **CI** (`.github/workflows/ci.yml`): runs on push/PR to master — `go build`, `go test`, `go vet`, and golangci-lint v2.11.4 (gosec, staticcheck, gocritic)
 - **Release** (`.github/workflows/release-please.yml`): runs on push to master — Release Please opens a Release PR; on merge, creates `v*` tag + GitHub Release, then GoReleaser publishes binaries (Linux/Darwin × amd64/arm64, `CGO_ENABLED=0`)
 - **Re-release** (`.github/workflows/release.yml`): manual `workflow_dispatch` fallback — re-runs GoReleaser for an existing tag
 - **Docs** (`.github/workflows/release-please.yml`): runs as part of the release process — zensical + mkdocs-macros-plugin → GitHub Pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ Run `go build`, `go test ./...`, and `golangci-lint run` inside as usual.
 
 GitHub Actions workflows:
 - **CI** (`.github/workflows/ci.yml`): runs on push/PR to master — `go build`, `go test`, `go vet`, and golangci-lint v2.11.4 (gosec, staticcheck, gocritic)
-- **Release** (`.github/workflows/release-please.yml`): runs on push to master — Release Please opens a Release PR; on merge, creates `v*` tag + GitHub Release, then GoReleaser publishes binaries (Linux/Darwin × amd64/arm64, `CGO_ENABLED=0`)
+- **Release** (`.github/workflows/release-please.yml`): runs on push to main — Release Please opens a Release PR; on merge, creates `v*` tag + GitHub Release, then GoReleaser publishes binaries (Linux/Darwin × amd64/arm64, `CGO_ENABLED=0`)
 - **Re-release** (`.github/workflows/release.yml`): manual `workflow_dispatch` fallback — re-runs GoReleaser for an existing tag
 - **Docs** (`.github/workflows/release-please.yml`): runs as part of the release process — zensical + mkdocs-macros-plugin → GitHub Pages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Go 1.26+
 - Docker (required for integration tests)
-- [golangci-lint](https://golangci-lint.run/welcome/install/) v2.10.1
+- [golangci-lint](https://golangci-lint.run/welcome/install/) v2.11.4
 
 ## Local setup
 

--- a/dev/Dockerfile.jailoc
+++ b/dev/Dockerfile.jailoc
@@ -28,7 +28,7 @@ RUN GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@${GOPLS_VERSION}
 
 # golangci-lint — static analysis matching CI (gosec, staticcheck, gocritic).
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-ARG GOLANGCI_LINT_VERSION=v2.10.1
+ARG GOLANGCI_LINT_VERSION=v2.11.4
 RUN set -eux; \
     ARCH=$(dpkg --print-architecture); \
     curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${ARCH}.tar.gz" \

--- a/internal/embed/assets/Dockerfile
+++ b/internal/embed/assets/Dockerfile
@@ -16,19 +16,19 @@
 # Pinned versions — Renovate comments tell the bot which datasource to poll
 # for automated version-bump PRs.
 # renovate: datasource=node-version depName=node versioning=node
-ARG NODE_VERSION=24.14.1
+ARG NODE_VERSION=24.15.0
 # renovate: datasource=npm depName=yaml-language-server
-ARG YAML_LS_VERSION=1.21.0
+ARG YAML_LS_VERSION=1.22.0
 # renovate: datasource=npm depName=typescript-language-server
 ARG TS_LS_VERSION=5.1.3
 # renovate: datasource=npm depName=typescript
-ARG TS_VERSION=6.0.2
+ARG TS_VERSION=6.0.3
 # renovate: datasource=npm depName=pyright
-ARG PYRIGHT_VERSION=1.1.408
+ARG PYRIGHT_VERSION=1.1.409
 # renovate: datasource=npm depName=bash-language-server
 ARG BASH_LS_VERSION=5.6.0
 # renovate: datasource=github-releases depName=sst/opencode
-ARG OPENCODE_VERSION=v1.4.6
+ARG OPENCODE_VERSION=v1.14.22
 
 # =============================================================================
 # Builder stage — compile language servers and install npm modules.


### PR DESCRIPTION
## Summary

- Bump OpenCode v1.4.6 → v1.14.22 (latest mainline)
- Bump Node.js 24.14.1 → 24.15.0 (LTS)
- Bump yaml-language-server 1.21.0 → 1.22.0
- Bump typescript 6.0.2 → 6.0.3
- Bump pyright 1.1.408 → 1.1.409
- Bump golangci-lint v2.10.1 → v2.11.4 (dev Dockerfile + CI)