### PR TITLE
feat(config): add enable_docker option to opt out of DinD sidecar

### DIFF
--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -2,7 +2,9 @@
 
 Every jailoc workspace runs as a Docker Compose project containing one or two containers, depending on whether Docker-in-Docker is enabled. Understanding why two containers exist when they do, and how they interact, helps explain both the security properties and some of the operational behaviour you'll observe when working with jailoc.
 
-## The two-container model
+## Container layout
+
+The diagram below shows the default two-container setup with Docker-in-Docker enabled. When `enable_docker` is `false`, jailoc starts only the **opencode** container — the dind sidecar, its volumes, and `DOCKER_HOST` environment variables are omitted entirely.
 
 ```mermaid
 flowchart TB

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -1,6 +1,6 @@
 # Container Architecture
 
-Every jailoc workspace runs as a Docker Compose project containing exactly two containers. Understanding why two containers exist, and how they interact, helps explain both the security properties and some of the operational behaviour you'll observe when working with jailoc.
+Every jailoc workspace runs as a Docker Compose project containing one or two containers, depending on whether Docker-in-Docker is enabled. Understanding why two containers exist when they do, and how they interact, helps explain both the security properties and some of the operational behaviour you'll observe when working with jailoc.
 
 ## The two-container model
 
@@ -30,6 +30,8 @@ The opencode container runs with configurable resource limits. The `cpu` (defaul
 
 The **dind container** runs a rootless Docker daemon (`docker:dind-rootless`) in privileged mode. The entrypoint installs iptables rules as root, then drops the inheritable and bounding capability sets before execing the rootless Docker daemon as UID 1000. The daemon listens on port 2376 with mutual TLS authentication, and the certificates are shared with the opencode container via a named volume. When the agent runs `docker build` or starts a database for testing, those containers exist entirely within the dind daemon's scope and are invisible to the host. Because the daemon runs rootless, inner containers operate inside a user namespace managed by rootlesskit — even `--privileged` inner containers cannot modify the outer network namespace's iptables rules.
 
+When `enable_docker` is `false`, the dind container is not started. The opencode container runs alone without Docker access — no dind service, no TLS certificate volumes, and no `DOCKER_HOST` environment variable. This reduces resource overhead and removes the privileged sidecar entirely.
+
 ## Network
 
 Both containers share a single Docker network named `jailoc`. The opencode container communicates with the dind daemon over this network via TLS on port 2376, and the same network carries the opencode container's egress traffic to the outside world. Network isolation is handled by iptables rules inside the opencode container rather than by network-level separation — see [Network Isolation](network-isolation.md) for details.
@@ -46,7 +48,7 @@ The opencode container mounts several things at startup:
 | SSH agent socket | read-write | Host SSH agent forwarded into the container (when `ssh_auth_sock = true`). Also mounts `~/.ssh/known_hosts` read-only for host key verification. |
 | `~/.gitconfig` | read-only | Host Git configuration (when `git_config = true`, the default) |
 
-Two named volumes are shared between both containers: one for TLS certificates (so the opencode container can authenticate to the dind daemon) and one for Docker's data directory. A third named volume holds the agent's own data — its SQLite history database and auth tokens. This last volume is intentionally isolated from your host's `~/.local/share/opencode`, so the agent's session history never touches your personal history.
+Two named volumes are shared between both containers when Docker-in-Docker is enabled: one for TLS certificates (so the opencode container can authenticate to the dind daemon) and one for Docker's data directory. When `enable_docker` is `false`, these volumes are not created. A third named volume holds the agent's own data — its SQLite history database and auth tokens. This last volume is intentionally isolated from your host's `~/.local/share/opencode`, so the agent's session history never touches your personal history.
 
 Environment variables configured via `env` or `env_file` in the workspace config or the `[defaults]` section are passed to the opencode container alongside the system variables required for dind connectivity. Values are literal strings — no host environment variable expansion is performed. jailoc also injects `JAILOC=1` and `JAILOC_WORKSPACE=<name>` into the opencode container; these are reserved and cannot be overridden by workspace config.
 
@@ -54,7 +56,7 @@ Environment variables configured via `env` or `env_file` in the workspace config
 
 The entrypoint script is bind-mounted into the container at runtime by jailoc and runs as root. It performs three distinct phases before handing off to the agent process.
 
-**Phase 1: Network rules.** The script installs iptables rules that shape what the agent can reach. It inserts ACCEPT rules for the dind container, the host gateway, DNS resolver addresses (port 53 only), and any hosts or networks you've allowed in config. It appends an ACCEPT rule for TCP replies on the published service port so that port-forwarded connections from the host can complete. It then appends DROP rules for RFC 1918 address space, link-local addresses, and CGNAT ranges. Public internet traffic is untouched. See [Network Isolation](network-isolation.md) for a full explanation of the security model.
+**Phase 1: Network rules.** The script installs iptables rules that shape what the agent can reach. When Docker-in-Docker is enabled, it inserts an ACCEPT rule for the dind container. It then inserts ACCEPT rules for the host gateway, DNS resolver addresses (port 53 only), and any hosts or networks you've allowed in config. It appends an ACCEPT rule for TCP replies on the published service port so that port-forwarded connections from the host can complete. It then appends DROP rules for RFC 1918 address space, link-local addresses, and CGNAT ranges. Public internet traffic is untouched. See [Network Isolation](network-isolation.md) for a full explanation of the security model.
 
 **Phase 2: Ownership fix.** Named volumes are created by Docker as root. The entrypoint runs `chown` on the data directories so UID 1000 can write to them once the privilege drop happens. If an SSH agent socket is mounted, its ownership is adjusted to UID 1000 as well. If the `~/.ssh` directory exists (from the known hosts mount), it is recursively owned to UID 1000.
 

--- a/docs/explanation/network-isolation.md
+++ b/docs/explanation/network-isolation.md
@@ -22,11 +22,11 @@ Public internet traffic is not blocked. The DROP rules are appended after the AC
 
 The rule ordering is the key mechanism. When the entrypoint installs iptables rules, it inserts ACCEPT rules at the top of the chain before adding the DROP rules at the bottom. Rules are evaluated in order, so an ACCEPT for a specific host wins against a later DROP for its containing range.
 
-Three things always get ACCEPT rules regardless of your config:
+Several things get ACCEPT rules before the DROP rules fire:
 
-1. The dind container's address, when `enable_docker` is `true` (so the agent can reach its Docker daemon)
-2. The host gateway (so DNS and the Docker bridge work)
-3. Any hosts or networks you've explicitly allowed in your workspace config
+- The **host gateway** (so DNS and the Docker bridge work) — always inserted
+- The **dind container's address** — inserted only when `enable_docker` is `true` (so the agent can reach its Docker daemon)
+- Any **hosts or networks** you've explicitly allowed in your workspace config
 
 DNS resolver addresses from `/etc/resolv.conf` also get ACCEPT rules, but only for port 53 (UDP and TCP). This is necessary because some container runtimes (notably Podman) place the DNS resolver at an address inside a blocked private range. Without this rule, hostname resolution would fail and the allowed-hosts mechanism would be useless. The rule is scoped to port 53 so the resolver IP cannot be used as a general-purpose gateway into the private network.
 

--- a/docs/explanation/network-isolation.md
+++ b/docs/explanation/network-isolation.md
@@ -24,7 +24,7 @@ The rule ordering is the key mechanism. When the entrypoint installs iptables ru
 
 Three things always get ACCEPT rules regardless of your config:
 
-1. The dind container's address (so the agent can reach its Docker daemon)
+1. The dind container's address, when `enable_docker` is `true` (so the agent can reach its Docker daemon)
 2. The host gateway (so DNS and the Docker bridge work)
 3. Any hosts or networks you've explicitly allowed in your workspace config
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Key facts:
 
-- jailoc runs two containers per workspace: an `opencode` container (the agent, UID 1000, capabilities dropped) and a `dind` sidecar (isolated Docker daemon)
+- jailoc runs two containers per workspace: an `opencode` container (the agent, UID 1000, capabilities dropped) and an optional `dind` sidecar (isolated Docker daemon, enabled by default via `enable_docker`)
 - Private networks (RFC 1918, link-local, CGNAT) are blocked by default via iptables; you allowlist specific hosts and CIDR ranges
 - Image resolution follows a 5-step cascade: workspace image → defaults image + workspace overlay → defaults image direct → base Dockerfile → embedded fallback
 - Config lives at `~/.config/jailoc/config.toml` (TOML); compose files are generated to `~/.cache/jailoc/{workspace}/docker-compose.yml`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,6 +65,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 | `expose_port` | bool | `true` | Expose the opencode container port to the host. When `false`, the `ports:` section is omitted from the generated compose file and the workspace is only accessible via `jailoc --exec`. |
 | `cpu` | float64 | `2.0` | Number of CPU cores allocated to the opencode container. Must be greater than 0. |
 | `memory` | string | `"4g"` | Memory limit for the opencode container. Accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` suffix (e.g. `512m`, `4g`, `1024`). Must be greater than 0. |
+| `enable_docker` | bool | `true` | Start a Docker-in-Docker sidecar alongside the opencode container. When `false`, the dind service, TLS certificate volumes, and `DOCKER_HOST`/`DOCKER_TLS_*` environment variables are omitted from the generated compose file, and the `docker` CLI is unavailable inside the container. Disabling reduces resource overhead and tightens security when the agent does not need Docker. |
 
 ### Example
 
@@ -78,6 +79,7 @@ allowed_hosts = ["internal-registry.example.com"]
 allowed_networks = ["10.0.0.0/8"]
 ssh_auth_sock = true
 git_config = true
+enable_docker = true
 cpu = 4.0
 memory = "8g"
 ```
@@ -107,6 +109,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | `expose_port` | bool | (inherit) | Expose the opencode container port to the host. When not set, inherits from `[defaults]`. Falls back to `true` when neither the workspace nor defaults set it. When `false`, `jailoc status` shows "not exposed (exec-only)" instead of the port number. |
 | `cpu` | float64 | (inherit) | Number of CPU cores allocated to the opencode container. When not set, inherits from `[defaults]`. Falls back to `2.0` when neither the workspace nor defaults set it. |
 | `memory` | string | (inherit) | Memory limit for the opencode container. When not set, inherits from `[defaults]`. Falls back to `"4g"` when neither the workspace nor defaults set it. |
+| `enable_docker` | bool | (inherit) | Start a Docker-in-Docker sidecar for this workspace. When not set, inherits from `[defaults]`. Falls back to `true` when neither the workspace nor defaults set it. When `false`, the dind service, TLS certificate volumes, and `DOCKER_HOST`/`DOCKER_TLS_*` environment variables are omitted. |
 
 !!! note
     `image` is mutually exclusive with `dockerfile` and `build_context`. Setting `image` alongside either of those fields is a validation error.
@@ -251,7 +254,7 @@ Environment variables from multiple sources are merged in this order (later entr
 | `/home/agent/.claude/transcripts` | `~/.claude/transcripts` | `rw` |
 | `/home/agent/.agents` | `~/.agents` | `ro` |
 
-`ssh_auth_sock`, `git_config`, and `expose_port` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config` and `expose_port` fall back to `true` when neither the workspace nor defaults set it.
+`ssh_auth_sock`, `git_config`, `expose_port`, and `enable_docker` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config`, `expose_port`, and `enable_docker` fall back to `true` when neither the workspace nor defaults set it.
 
 `cpu` and `memory` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `cpu` falls back to `2.0` and `memory` falls back to `"4g"` when neither the workspace nor defaults set them.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,7 +65,7 @@ Global defaults applied to all workspaces. All fields are optional and default t
 | `expose_port` | bool | `true` | Expose the opencode container port to the host. When `false`, the `ports:` section is omitted from the generated compose file and the workspace is only accessible via `jailoc --exec`. |
 | `cpu` | float64 | `2.0` | Number of CPU cores allocated to the opencode container. Must be greater than 0. |
 | `memory` | string | `"4g"` | Memory limit for the opencode container. Accepts Docker memory format: a positive integer optionally followed by `k`, `m`, or `g` suffix (e.g. `512m`, `4g`, `1024`). Must be greater than 0. |
-| `enable_docker` | bool | `true` | Start a Docker-in-Docker sidecar alongside the opencode container. When `false`, the dind service, TLS certificate volumes, and `DOCKER_HOST`/`DOCKER_TLS_*` environment variables are omitted from the generated compose file, and the `docker` CLI is unavailable inside the container. Disabling reduces resource overhead and tightens security when the agent does not need Docker. |
+| `enable_docker` | bool | `true` | Start a Docker-in-Docker sidecar alongside the opencode container. When `false`, the dind service, TLS certificate volumes, and `DOCKER_HOST`/`DOCKER_TLS_*` environment variables are omitted from the generated compose file, so Docker access from inside the container is unavailable by default and `docker` commands will not be able to connect to a daemon. Disabling reduces resource overhead and tightens security when the agent does not need Docker. |
 
 ### Example
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -143,6 +143,7 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		UseDataVolume:    !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.local/share/opencode"),
 		UseCacheVolume:   !compose.MountsContainTarget(ws2.Mounts, "/home/agent/.cache"),
 		ExposePort:       ws2.ExposePort,
+		EnableDocker:     ws2.EnableDocker,
 	}
 
 	if err := config.WriteAllowedFiles(ws2.Name, cfg); err != nil {
@@ -153,8 +154,10 @@ func maybeRestartWorkspace(ctx context.Context, ws *workspace.Resolved) error {
 		return err
 	}
 
-	if err := writeDindEntrypoint(filepath.Dir(compPath)); err != nil {
-		return err
+	if ws2.EnableDocker {
+		if err := writeDindEntrypoint(filepath.Dir(compPath)); err != nil {
+			return err
+		}
 	}
 
 	if err := compose.WriteComposeFile(params, compPath); err != nil {

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -136,8 +136,10 @@ func runUp(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if err := writeDindEntrypoint(cacheDir); err != nil {
-		return err
+	if ws.EnableDocker {
+		if err := writeDindEntrypoint(cacheDir); err != nil {
+			return err
+		}
 	}
 
 	if err := writeTUIConfig(jailocCacheDir()); err != nil {
@@ -168,6 +170,7 @@ func runUp(ctx context.Context, args []string) error {
 		UseDataVolume:    !compose.MountsContainTarget(ws.Mounts, "/home/agent/.local/share/opencode"),
 		UseCacheVolume:   !compose.MountsContainTarget(ws.Mounts, "/home/agent/.cache"),
 		ExposePort:       ws.ExposePort,
+		EnableDocker:     ws.EnableDocker,
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Generating compose configuration...\n")

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -28,6 +28,7 @@ type ComposeParams struct {
 	UseDataVolume    bool
 	UseCacheVolume   bool
 	ExposePort       bool
+	EnableDocker     bool
 }
 
 func GenerateCompose(params ComposeParams) ([]byte, error) {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -227,6 +227,13 @@ func assertContains(t *testing.T, haystack, needle string) {
 	}
 }
 
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("expected rendered compose NOT to contain %q, got:\n%s", needle, haystack)
+	}
+}
+
 func TestGenerateComposeSSHAuthSock(t *testing.T) {
 	t.Parallel()
 
@@ -413,6 +420,7 @@ func TestGenerateComposeEnv(t *testing.T) {
 		Env:    []string{"MY_VAR=hello", "OTHER=world"},
 		CPU:              2.0,
 		Memory:           "4g",
+		EnableDocker:     true,
 	}
 
 	out, err := GenerateCompose(params)
@@ -443,6 +451,7 @@ func TestGenerateComposeEmptyEnv(t *testing.T) {
 		Env:    nil,
 		CPU:              2.0,
 		Memory:           "4g",
+		EnableDocker:     true,
 	}
 
 	out, err := GenerateCompose(params)
@@ -843,4 +852,76 @@ func TestGenerateComposeMountOrderAfterNamedVolumes(t *testing.T) {
 	if mountIdx < dataVolIdx {
 		t.Fatalf("expected user mounts to appear after named volumes so they take precedence;\nnamed volume at index %d, user mount at index %d", dataVolIdx, mountIdx)
 	}
+}
+
+func TestGenerateComposeEnableDockerFalse(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "no-docker-test",
+		Port:          4900,
+		Image:         "ghcr.io/seznam/jailoc:test",
+		Paths:         []string{"/tmp/work"},
+		CPU:           2.0,
+		Memory:        "4g",
+		EnableDocker:  false,
+	}
+
+	out, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose returned error: %v", err)
+	}
+
+	rendered := string(out)
+
+	// DinD service must not be present
+	assertNotContains(t, rendered, "dind:")
+	assertNotContains(t, rendered, "docker:dind-rootless")
+
+	// Docker env vars must not be present
+	assertNotContains(t, rendered, "DOCKER_HOST")
+	assertNotContains(t, rendered, "DOCKER_TLS_CERTDIR")
+	assertNotContains(t, rendered, "DOCKER_CERT_PATH")
+	assertNotContains(t, rendered, "DOCKER_TLS_VERIFY")
+
+	// DinD volumes must not be present
+	assertNotContains(t, rendered, "dind-certs")
+	assertNotContains(t, rendered, "dind-data")
+
+	// Basic service must still be present
+	assertContains(t, rendered, "opencode:")
+	assertContains(t, rendered, "- JAILOC=1")
+}
+
+func TestGenerateComposeEnableDockerTrue(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName: "docker-test",
+		Port:          4901,
+		Image:         "ghcr.io/seznam/jailoc:test",
+		Paths:         []string{"/tmp/work"},
+		CPU:           2.0,
+		Memory:        "4g",
+		EnableDocker:  true,
+	}
+
+	out, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose returned error: %v", err)
+	}
+
+	rendered := string(out)
+
+	// DinD service must be present
+	assertContains(t, rendered, "dind:")
+	assertContains(t, rendered, "docker:dind-rootless")
+
+	// Docker env vars must be present
+	assertContains(t, rendered, "DOCKER_HOST=tcp://dind:2376")
+	assertContains(t, rendered, "DOCKER_TLS_VERIFY=1")
+
+	// DinD volumes must be present
+	assertContains(t, rendered, "dind-certs-client:/certs/client:ro")
+	assertContains(t, rendered, "dind-data:")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ const (
 # ssh_auth_sock = false
 # git_config = true
 # expose_port = true
+# enable_docker = true
 # cpu = 2.0
 # memory = "4g"
 
@@ -53,6 +54,7 @@ paths = []
 # ssh_auth_sock = false
 # git_config = true
 # expose_port = true
+# enable_docker = true
 # cpu = 2.0
 # memory = "4g"
 `
@@ -172,6 +174,7 @@ type Defaults struct {
 	CPU             *float64 `toml:"cpu"`
 	Memory          *string  `toml:"memory"`
 	ExposePort      *bool    `toml:"expose_port"`
+	EnableDocker    *bool    `toml:"enable_docker"`
 }
 
 type Workspace struct {
@@ -189,6 +192,7 @@ type Workspace struct {
 	CPU             *float64 `toml:"cpu"`
 	Memory          *string  `toml:"memory"`
 	ExposePort      *bool    `toml:"expose_port"`
+	EnableDocker    *bool    `toml:"enable_docker"`
 }
 
 func ConfigDir() string {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -88,9 +88,12 @@ func (c *Client) Up(ctx context.Context) error {
 		return fmt.Errorf("load compose project for workspace %q: %w", c.workspace, err)
 	}
 
-	// Default UpOptions uses RecreateDiverged: containers are recreated only
-	// when the compose configuration changes (e.g. new env vars, image update).
-	if err := c.svc.Up(ctx, project, api.UpOptions{}); err != nil {
+	// RecreateDiverged (default): containers are recreated only when the
+	// compose configuration changes. RemoveOrphans removes services that are
+	// no longer defined (e.g. dind after disabling enable_docker).
+	if err := c.svc.Up(ctx, project, api.UpOptions{
+		Create: api.CreateOptions{RemoveOrphans: true},
+	}); err != nil {
 		return fmt.Errorf("compose up for workspace %q: %w", c.workspace, err)
 	}
 

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -109,6 +109,8 @@ services:
       - "2376"
 {{- end}}
 
+{{- if or .UseDataVolume .UseCacheVolume .EnableDocker}}
+
 volumes:
 {{- if .UseDataVolume}}
   opencode-data-{{.WorkspaceName}}:
@@ -120,6 +122,7 @@ volumes:
   dind-certs-ca:
   dind-certs-client:
   dind-data:
+{{- end}}
 {{- end}}
 
 networks:

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -25,7 +25,9 @@ services:
       - ${HOME}/.cache/jailoc/{{.WorkspaceName}}/entrypoint.sh:/usr/local/bin/entrypoint.sh:ro
       - ${HOME}/.cache/jailoc/tui-container.json:/etc/jailoc-tui.json:ro
       - ${HOME}/.cache/jailoc/tui-plugin:/etc/jailoc-tui-plugin:ro
+{{- if .EnableDocker}}
       - dind-certs-client:/certs/client:ro
+{{- end}}
 {{- if .SSHAuthSock}}
       - {{.SSHAuthSock}}:/run/ssh-agent.sock
 {{- end}}
@@ -38,10 +40,12 @@ services:
     environment:
       - OPENCODE_LOG=debug
       - OPENCODE_SERVER_PASSWORD=${OPENCODE_SERVER_PASSWORD}
+{{- if .EnableDocker}}
       - DOCKER_HOST=tcp://dind:2376
       - DOCKER_TLS_CERTDIR=/certs
       - DOCKER_CERT_PATH=/certs/client
       - DOCKER_TLS_VERIFY=1
+{{- end}}
       - JAILOC=1
       - JAILOC_WORKSPACE={{.WorkspaceName}}
 {{- if .SSHAuthSock}}
@@ -80,6 +84,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
+{{- if .EnableDocker}}
 
   dind:
     image: docker:dind-rootless
@@ -102,6 +107,7 @@ services:
       - jailoc
     expose:
       - "2376"
+{{- end}}
 
 volumes:
 {{- if .UseDataVolume}}
@@ -110,9 +116,11 @@ volumes:
 {{- if .UseCacheVolume}}
   opencode-cache-{{.WorkspaceName}}:
 {{- end}}
+{{- if .EnableDocker}}
   dind-certs-ca:
   dind-certs-client:
   dind-data:
+{{- end}}
 
 networks:
   jailoc:

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -24,7 +24,9 @@ else
 fi
 
 # --- Allow infrastructure targets ---
-$IPT -I OUTPUT -d dind -j ACCEPT
+if [ -n "${DOCKER_HOST:-}" ]; then
+  $IPT -I OUTPUT -d dind -j ACCEPT
+fi
 
 HOST_IP=$(getent hosts host.docker.internal | awk '{print $1}' || true)
 if [ -n "$HOST_IP" ]; then

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -24,8 +24,13 @@ else
 fi
 
 # --- Allow infrastructure targets ---
-if [ -n "${DOCKER_HOST:-}" ]; then
-  $IPT -I OUTPUT -d dind -j ACCEPT
+DIND_DOCKER_HOST="${DOCKER_HOST:-}"
+if [[ "$DIND_DOCKER_HOST" == "tcp://dind" || "$DIND_DOCKER_HOST" == tcp://dind:* ]]; then
+  if getent hosts dind >/dev/null 2>&1; then
+    $IPT -I OUTPUT -d dind -j ACCEPT
+  else
+    echo "jailoc: WARNING: DOCKER_HOST points at dind, but dind could not be resolved; skipping DinD allow rule" >&2
+  fi
 fi
 
 HOST_IP=$(getent hosts host.docker.internal | awk '{print $1}' || true)

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -26,10 +26,22 @@ fi
 # --- Allow infrastructure targets ---
 DIND_DOCKER_HOST="${DOCKER_HOST:-}"
 if [[ "$DIND_DOCKER_HOST" == "tcp://dind" || "$DIND_DOCKER_HOST" == tcp://dind:* ]]; then
-  if getent hosts dind >/dev/null 2>&1; then
+  DIND_RESOLVE_ATTEMPTS=10
+  DIND_RESOLVED=0
+  while [ "$DIND_RESOLVE_ATTEMPTS" -gt 0 ]; do
+    if getent hosts dind >/dev/null 2>&1; then
+      DIND_RESOLVED=1
+      break
+    fi
+    DIND_RESOLVE_ATTEMPTS=$((DIND_RESOLVE_ATTEMPTS - 1))
+    [ "$DIND_RESOLVE_ATTEMPTS" -gt 0 ] && sleep 1
+  done
+
+  if [ "$DIND_RESOLVED" -eq 1 ]; then
     $IPT -I OUTPUT -d dind -j ACCEPT
   else
-    echo "jailoc: WARNING: DOCKER_HOST points at dind, but dind could not be resolved; skipping DinD allow rule" >&2
+    echo "jailoc: FATAL: DOCKER_HOST points at dind, but dind could not be resolved; cannot install DinD allow rule" >&2
+    exit 1
   fi
 fi
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -36,6 +36,7 @@ type Resolved struct {
 	CPU             float64
 	Memory          string
 	ExposePort      bool
+	EnableDocker    bool
 }
 
 func Resolve(cfg *config.Config, name string) (*Resolved, error) {
@@ -117,6 +118,7 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 		CPU:             floatWithDefault(cfg.Defaults.CPU, ws.CPU, 2.0),
 		Memory:          stringWithDefault(cfg.Defaults.Memory, ws.Memory, "4g"),
 		ExposePort:      boolPtrWithDefault(cfg.Defaults.ExposePort, ws.ExposePort, true),
+		EnableDocker:    boolPtrWithDefault(cfg.Defaults.EnableDocker, ws.EnableDocker, true),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Add `enable_docker` workspace/defaults config option (`*bool`, default `true`) to disable the DinD sidecar per workspace
- When `false`: omit dind service + volumes from compose, skip Docker env vars and TLS cert mount, skip dind-entrypoint write, skip dind iptables rule in entrypoint

Closes #76