### PR TITLE
feat(cmd): add session continuation and rewrite exit title

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
             ];
           };
 
-          vendorHash = "sha256-F3Lcoqzf/3a6fs45i8VRdn9KB2xHOfuGv3DsawL1I/U=";
+          vendorHash = "sha256-FyttN9MPt91ryMFdYFYhjFAyARAiO9TQYtkqjuecWhw=";
 
           subPackages = [ "cmd/jailoc" ];
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/creack/pty/v2 v2.0.1
 	github.com/docker/cli v29.4.1+incompatible
 	github.com/docker/compose/v5 v5.1.3
 	github.com/docker/docker v28.5.2+incompatible
@@ -36,7 +37,6 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.4 // indirect
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
-	github.com/creack/pty/v2 v2.0.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/buildx v0.33.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.4 // indirect
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
+	github.com/creack/pty/v2 v2.0.1 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/buildx v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsx
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/creack/pty/v2 v2.0.1 h1:RDY1VY5b+7m2mfPsugucOYPIxMp+xal5ZheSyVzUA+k=
+github.com/creack/pty/v2 v2.0.1/go.mod h1:2dSssKp3b86qYEMwA/FPwc3ff+kYpDdQI8osU8J7gxQ=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -193,6 +193,8 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	if term.IsTerminal(fd) {
 		oldState, rawErr := term.MakeRaw(fd)
 		if rawErr != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
 			return fmt.Errorf("set raw terminal: %w", rawErr)
 		}
 		defer func() { _ = term.Restore(fd, oldState) }()
@@ -224,9 +226,10 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	err = cmd.Wait()
 	closeWaitDone()
 	_ = ptmx.Close()
-	// Report copy errors only when the process exited cleanly — PTY read
-	// errors are expected once the child exits.
-	if copyErr != nil && err == nil {
+	// PTY reads commonly return EIO when the slave side closes on normal
+	// process exit — treat it as expected EOF. Surface other copy errors
+	// only when the process itself exited cleanly.
+	if copyErr != nil && err == nil && !errors.Is(copyErr, syscall.EIO) {
 		err = fmt.Errorf("copy pty output: %w", copyErr)
 	}
 	if ferr := rw.Flush(); ferr != nil && err == nil {
@@ -380,11 +383,11 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		if idx >= 0 {
 			if idx > 0 {
 				if _, err := r.w.Write(data[:idx]); err != nil {
-					return len(p), err
+					return 0, err
 				}
 			}
 			if _, err := r.w.Write(exitReplace); err != nil {
-				return len(p), err
+				return 0, err
 			}
 			data = data[idx+len(exitMatch):]
 			continue
@@ -401,7 +404,7 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		flush := data[:len(data)-keep]
 		if len(flush) > 0 {
 			if _, err := r.w.Write(flush); err != nil {
-				return len(p), err
+				return 0, err
 			}
 		}
 		r.buf = append(r.buf[:0], data[len(data)-keep:]...)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -160,6 +161,8 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	}()
 
 	waitDone := make(chan struct{})
+	closeWaitDone := sync.OnceFunc(func() { close(waitDone) })
+	defer closeWaitDone()
 
 	// Forward terminal resizes to the PTY.
 	sigCh := make(chan os.Signal, 1)
@@ -218,7 +221,7 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	_, copyErr := io.Copy(rw, ptmx)
 
 	err = cmd.Wait()
-	close(waitDone)
+	closeWaitDone()
 	_ = ptmx.Close()
 	// Report copy errors only when the process exited cleanly — PTY read
 	// errors are expected once the child exits.

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -157,7 +157,9 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		}
 		return cmd.Process.Signal(syscall.SIGTERM)
 	}, attachWaitDelay)
-	_ = rw.Flush()
+	if ferr := rw.Flush(); ferr != nil && err == nil {
+		err = fmt.Errorf("flush exit rewriter: %w", ferr)
+	}
 	return attachResult(ctx, err)
 }
 
@@ -184,7 +186,9 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 	serverURL := fmt.Sprintf("http://localhost:%d", workspace.BasePort)
 	rw := &exitRewriter{w: os.Stdout}
 	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, rw, os.Stderr)
-	_ = rw.Flush()
+	if ferr := rw.Flush(); ferr != nil && err == nil {
+		err = fmt.Errorf("flush exit rewriter: %w", ferr)
+	}
 	return attachResult(ctx, err)
 }
 
@@ -309,7 +313,7 @@ var (
 
 func (r *exitRewriter) Write(p []byte) (int, error) {
 	n := len(p)
-	data := append(r.buf, p...) //nolint:gocritic // intentional append to new slice
+	data := append(r.buf, p...) //nolint:gocritic // append merges buf and p; may reuse buf's backing array
 	r.buf = r.buf[:0]
 
 	for {

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -361,6 +361,18 @@ func runCommandWithContext(ctx context.Context, cmd *exec.Cmd, terminate func() 
 	}
 }
 
+// writeAll writes the entire slice to w, retrying on short writes.
+func writeAll(w io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := w.Write(data)
+		data = data[n:]
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // exitRewriter wraps an io.Writer and replaces occurrences of "opencode -s "
 // with "jailoc -s " in the output stream. It handles partial matches that
 // span Write boundaries by buffering a small suffix.
@@ -382,12 +394,12 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		idx := bytes.Index(data, exitMatch)
 		if idx >= 0 {
 			if idx > 0 {
-				if _, err := r.w.Write(data[:idx]); err != nil {
-					return 0, err
+				if err := writeAll(r.w, data[:idx]); err != nil {
+					return len(p), err
 				}
 			}
-			if _, err := r.w.Write(exitReplace); err != nil {
-				return 0, err
+			if err := writeAll(r.w, exitReplace); err != nil {
+				return len(p), err
 			}
 			data = data[idx+len(exitMatch):]
 			continue
@@ -403,8 +415,8 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 
 		flush := data[:len(data)-keep]
 		if len(flush) > 0 {
-			if _, err := r.w.Write(flush); err != nil {
-				return 0, err
+			if err := writeAll(r.w, flush); err != nil {
+				return len(p), err
 			}
 		}
 		r.buf = append(r.buf[:0], data[len(data)-keep:]...)
@@ -417,7 +429,7 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 // Flush writes any buffered partial-match bytes to the underlying writer.
 func (r *exitRewriter) Flush() error {
 	if len(r.buf) > 0 {
-		_, err := r.w.Write(r.buf)
+		err := writeAll(r.w, r.buf)
 		r.buf = r.buf[:0]
 		return err
 	}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -177,6 +177,7 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	}()
 	defer func() {
 		signal.Stop(sigCh)
+		close(sigCh)
 		<-sigDone
 	}()
 	_ = pty.InheritSize(os.Stdin, ptmx)
@@ -362,11 +363,11 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		if idx >= 0 {
 			if idx > 0 {
 				if _, err := r.w.Write(data[:idx]); err != nil {
-					return 0, err
+					return len(p), err
 				}
 			}
 			if _, err := r.w.Write(exitReplace); err != nil {
-				return 0, err
+				return len(p), err
 			}
 			data = data[idx+len(exitMatch):]
 			continue
@@ -383,7 +384,7 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		flush := data[:len(data)-keep]
 		if len(flush) > 0 {
 			if _, err := r.w.Write(flush); err != nil {
-				return 0, err
+				return len(p), err
 			}
 		}
 		r.buf = append(r.buf[:0], data[len(data)-keep:]...)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -159,6 +159,8 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		_ = ptmx.Close()
 	}()
 
+	waitDone := make(chan struct{})
+
 	// Forward terminal resizes to the PTY.
 	sigCh := make(chan os.Signal, 1)
 	sigDone := make(chan struct{})
@@ -167,37 +169,34 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		defer close(sigDone)
 		for {
 			select {
-			case _, ok := <-sigCh:
-				if !ok {
-					return
-				}
+			case <-sigCh:
 				_ = pty.InheritSize(os.Stdin, ptmx)
 			case <-ctx.Done():
+				return
+			case <-waitDone:
 				return
 			}
 		}
 	}()
 	defer func() {
 		signal.Stop(sigCh)
-		close(sigCh)
 		<-sigDone
 	}()
 	_ = pty.InheritSize(os.Stdin, ptmx)
 
 	// Raw mode so keystrokes pass through verbatim (Ctrl-C, arrows, etc.).
 	fd := int(os.Stdin.Fd()) //nolint:gosec // Fd() fits in int on all supported platforms
-	if oldState, restoreErr := term.MakeRaw(fd); restoreErr == nil {
+	if term.IsTerminal(fd) {
+		oldState, rawErr := term.MakeRaw(fd)
+		if rawErr != nil {
+			return fmt.Errorf("set raw terminal: %w", rawErr)
+		}
 		defer func() { _ = term.Restore(fd, oldState) }()
 	}
 
-	stdinDone := make(chan struct{})
-	go func() {
-		defer close(stdinDone)
-		_, _ = io.Copy(ptmx, os.Stdin)
-	}()
+	go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
 
 	// Cancel the child process when the context is done (e.g. container stops).
-	waitDone := make(chan struct{})
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -221,7 +220,6 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	err = cmd.Wait()
 	close(waitDone)
 	_ = ptmx.Close()
-	<-stdinDone
 	// Report copy errors only when the process exited cleanly — PTY read
 	// errors are expected once the child exits.
 	if copyErr != nil && err == nil {

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/creack/pty/v2"
 	"golang.org/x/term"
 
 	"github.com/seznam/jailoc/internal/config"
@@ -137,9 +138,6 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	}
 	args := attachHostArgs(serverArg, pw, dir, session, cont)
 	cmd := exec.Command(binary, args...) //nolint:gosec // binary name is from ResolveBinary, args are controlled
-	cmd.Stdin = os.Stdin
-	rw := &exitRewriter{w: os.Stdout}
-	cmd.Stdout = rw
 	cmd.Stderr = os.Stderr
 
 	tuiPath := filepath.Join(jailocCacheDir(), "tui.json")
@@ -151,12 +149,53 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		cmd.Env = envWithOverrides(cmd.Env, env...)
 	}
 
-	err = runCommandWithContext(ctx, cmd, func() error {
-		if cmd.Process == nil {
-			return nil
+	// PTY keeps isTTY=true for the child (required by opentui) while letting
+	// us intercept stdout through the exitRewriter.
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("start command with pty: %w", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	// Forward terminal resizes to the PTY.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	go func() {
+		for range sigCh {
+			_ = pty.InheritSize(os.Stdin, ptmx)
 		}
-		return cmd.Process.Signal(syscall.SIGTERM)
-	}, attachWaitDelay)
+	}()
+	defer func() {
+		signal.Stop(sigCh)
+		close(sigCh)
+	}()
+	_ = pty.InheritSize(os.Stdin, ptmx)
+
+	// Raw mode so keystrokes pass through verbatim (Ctrl-C, arrows, etc.).
+	fd := int(os.Stdin.Fd()) //nolint:gosec // Fd() fits in int on all supported platforms
+	if oldState, restoreErr := term.MakeRaw(fd); restoreErr == nil {
+		defer func() { _ = term.Restore(fd, oldState) }()
+	}
+
+	go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
+
+	// Cancel the child process when the context is done (e.g. container stops).
+	go func() {
+		<-ctx.Done()
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+			time.AfterFunc(attachWaitDelay, func() {
+				if cmd.Process != nil {
+					_ = cmd.Process.Kill()
+				}
+			})
+		}
+	}()
+
+	rw := &exitRewriter{w: os.Stdout}
+	_, _ = io.Copy(rw, ptmx)
+
+	err = cmd.Wait()
 	if ferr := rw.Flush(); ferr != nil && err == nil {
 		err = fmt.Errorf("flush exit rewriter: %w", ferr)
 	}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -155,7 +155,9 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	if err != nil {
 		return fmt.Errorf("start command with pty: %w", err)
 	}
-	defer func() { _ = ptmx.Close() }()
+	defer func() {
+		_ = ptmx.Close()
+	}()
 
 	// Forward terminal resizes to the PTY.
 	sigCh := make(chan os.Signal, 1)
@@ -188,18 +190,28 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		defer func() { _ = term.Restore(fd, oldState) }()
 	}
 
-	go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
+	stdinDone := make(chan struct{})
+	go func() {
+		defer close(stdinDone)
+		_, _ = io.Copy(ptmx, os.Stdin)
+	}()
 
 	// Cancel the child process when the context is done (e.g. container stops).
+	waitDone := make(chan struct{})
 	go func() {
-		<-ctx.Done()
-		if cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-			time.AfterFunc(attachWaitDelay, func() {
-				if cmd.Process != nil {
-					_ = cmd.Process.Kill()
+		select {
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(syscall.SIGTERM)
+				select {
+				case <-waitDone:
+				case <-time.After(attachWaitDelay):
+					if cmd.Process != nil {
+						_ = cmd.Process.Kill()
+					}
 				}
-			})
+			}
+		case <-waitDone:
 		}
 	}()
 
@@ -207,6 +219,9 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	_, copyErr := io.Copy(rw, ptmx)
 
 	err = cmd.Wait()
+	close(waitDone)
+	_ = ptmx.Close()
+	<-stdinDone
 	// Report copy errors only when the process exited cleanly — PTY read
 	// errors are expected once the child exits.
 	if copyErr != nil && err == nil {

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -183,6 +183,7 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	}()
 	defer func() {
 		signal.Stop(sigCh)
+		closeWaitDone()
 		<-sigDone
 	}()
 	_ = pty.InheritSize(os.Stdin, ptmx)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -165,10 +165,7 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 			_ = pty.InheritSize(os.Stdin, ptmx)
 		}
 	}()
-	defer func() {
-		signal.Stop(sigCh)
-		close(sigCh)
-	}()
+	defer signal.Stop(sigCh)
 	_ = pty.InheritSize(os.Stdin, ptmx)
 
 	// Raw mode so keystrokes pass through verbatim (Ctrl-C, arrows, etc.).
@@ -193,9 +190,14 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	}()
 
 	rw := &exitRewriter{w: os.Stdout}
-	_, _ = io.Copy(rw, ptmx)
+	_, copyErr := io.Copy(rw, ptmx)
 
 	err = cmd.Wait()
+	// Report copy errors only when the process exited cleanly — PTY read
+	// errors are expected once the child exits.
+	if copyErr != nil && err == nil {
+		err = fmt.Errorf("copy pty output: %w", copyErr)
+	}
 	if ferr := rw.Flush(); ferr != nil && err == nil {
 		err = fmt.Errorf("flush exit rewriter: %w", ferr)
 	}
@@ -217,10 +219,7 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 			// Terminal resize is forwarded by the exec stream automatically.
 		}
 	}()
-	defer func() {
-		signal.Stop(sigCh)
-		close(sigCh)
-	}()
+	defer signal.Stop(sigCh)
 
 	serverURL := fmt.Sprintf("http://localhost:%d", workspace.BasePort)
 	rw := &exitRewriter{w: os.Stdout}
@@ -351,7 +350,6 @@ var (
 )
 
 func (r *exitRewriter) Write(p []byte) (int, error) {
-	n := len(p)
 	data := append(r.buf, p...) //nolint:gocritic // append merges buf and p; may reuse buf's backing array
 	r.buf = r.buf[:0]
 
@@ -360,11 +358,11 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		if idx >= 0 {
 			if idx > 0 {
 				if _, err := r.w.Write(data[:idx]); err != nil {
-					return n, err
+					return 0, err
 				}
 			}
 			if _, err := r.w.Write(exitReplace); err != nil {
-				return n, err
+				return 0, err
 			}
 			data = data[idx+len(exitMatch):]
 			continue
@@ -381,14 +379,14 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 		flush := data[:len(data)-keep]
 		if len(flush) > 0 {
 			if _, err := r.w.Write(flush); err != nil {
-				return n, err
+				return 0, err
 			}
 		}
 		r.buf = append(r.buf[:0], data[len(data)-keep:]...)
 		break
 	}
 
-	return n, nil
+	return len(p), nil
 }
 
 // Flush writes any buffered partial-match bytes to the underlying writer.

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -163,13 +163,20 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	signal.Notify(sigCh, syscall.SIGWINCH)
 	go func() {
 		defer close(sigDone)
-		for range sigCh {
-			_ = pty.InheritSize(os.Stdin, ptmx)
+		for {
+			select {
+			case _, ok := <-sigCh:
+				if !ok {
+					return
+				}
+				_ = pty.InheritSize(os.Stdin, ptmx)
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 	defer func() {
 		signal.Stop(sigCh)
-		close(sigCh)
 		<-sigDone
 	}()
 	_ = pty.InheritSize(os.Stdin, ptmx)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -20,7 +22,7 @@ import (
 	"github.com/seznam/jailoc/internal/workspace"
 )
 
-func attachHostArgs(serverURL, password, dir string) []string {
+func attachHostArgs(serverURL, password, dir, session string, cont bool) []string {
 	args := []string{"attach", serverURL}
 	if password != "" {
 		args = append(args, "--password", password)
@@ -28,13 +30,25 @@ func attachHostArgs(serverURL, password, dir string) []string {
 	if dir != "" {
 		args = append(args, "--dir", dir)
 	}
+	if session != "" {
+		args = append(args, "--session", session)
+	}
+	if cont {
+		args = append(args, "--continue")
+	}
 	return args
 }
 
-func attachExecArgs(serverURL, dir string) []string {
+func attachExecArgs(serverURL, dir, session string, cont bool) []string {
 	args := []string{"opencode", "attach", serverURL}
 	if dir != "" {
 		args = append(args, "--dir", dir)
+	}
+	if session != "" {
+		args = append(args, "--session", session)
+	}
+	if cont {
+		args = append(args, "--continue")
 	}
 	return args
 }
@@ -108,7 +122,7 @@ func envWithOverrides(base []string, overrides ...string) []string {
 	return append(filtered, overrides...)
 }
 
-func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passwordMode string) error {
+func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passwordMode string, session string, cont bool) error {
 	binary, err := config.ResolveBinary()
 	if err != nil {
 		return fmt.Errorf("resolve opencode binary: %w", err)
@@ -121,10 +135,11 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	if err != nil {
 		return err
 	}
-	args := attachHostArgs(serverArg, pw, dir)
+	args := attachHostArgs(serverArg, pw, dir, session, cont)
 	cmd := exec.Command(binary, args...) //nolint:gosec // binary name is from ResolveBinary, args are controlled
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
+	rw := &exitRewriter{w: os.Stdout}
+	cmd.Stdout = rw
 	cmd.Stderr = os.Stderr
 
 	tuiPath := filepath.Join(jailocCacheDir(), "tui.json")
@@ -142,10 +157,11 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		}
 		return cmd.Process.Signal(syscall.SIGTERM)
 	}, attachWaitDelay)
+	_ = rw.Flush()
 	return attachResult(ctx, err)
 }
 
-func attachExec(ctx context.Context, client *docker.Client, dir string) error {
+func attachExec(ctx context.Context, client *docker.Client, dir string, session string, cont bool) error {
 	fd := int(os.Stdin.Fd()) //nolint:gosec // Fd() fits in int on all supported platforms
 	oldState, err := term.MakeRaw(fd)
 	if err != nil {
@@ -166,7 +182,9 @@ func attachExec(ctx context.Context, client *docker.Client, dir string) error {
 	}()
 
 	serverURL := fmt.Sprintf("http://localhost:%d", workspace.BasePort)
-	err = client.Exec(ctx, attachExecArgs(serverURL, dir), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, os.Stdout, os.Stderr)
+	rw := &exitRewriter{w: os.Stdout}
+	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, rw, os.Stderr)
+	_ = rw.Flush()
 	return attachResult(ctx, err)
 }
 
@@ -274,4 +292,68 @@ func runCommandWithContext(ctx context.Context, cmd *exec.Cmd, terminate func() 
 			return <-resultCh
 		}
 	}
+}
+
+// exitRewriter wraps an io.Writer and replaces occurrences of "opencode -s "
+// with "jailoc -s " in the output stream. It handles partial matches that
+// span Write boundaries by buffering a small suffix.
+type exitRewriter struct {
+	w   io.Writer
+	buf []byte
+}
+
+var (
+	exitMatch   = []byte("opencode -s ")
+	exitReplace = []byte("jailoc -s ")
+)
+
+func (r *exitRewriter) Write(p []byte) (int, error) {
+	n := len(p)
+	data := append(r.buf, p...) //nolint:gocritic // intentional append to new slice
+	r.buf = r.buf[:0]
+
+	for {
+		idx := bytes.Index(data, exitMatch)
+		if idx >= 0 {
+			if idx > 0 {
+				if _, err := r.w.Write(data[:idx]); err != nil {
+					return n, err
+				}
+			}
+			if _, err := r.w.Write(exitReplace); err != nil {
+				return n, err
+			}
+			data = data[idx+len(exitMatch):]
+			continue
+		}
+
+		// Keep any suffix that could be the start of exitMatch.
+		keep := 0
+		for i := 1; i < len(exitMatch) && i <= len(data); i++ {
+			if bytes.Equal(data[len(data)-i:], exitMatch[:i]) {
+				keep = i
+			}
+		}
+
+		flush := data[:len(data)-keep]
+		if len(flush) > 0 {
+			if _, err := r.w.Write(flush); err != nil {
+				return n, err
+			}
+		}
+		r.buf = append(r.buf[:0], data[len(data)-keep:]...)
+		break
+	}
+
+	return n, nil
+}
+
+// Flush writes any buffered partial-match bytes to the underlying writer.
+func (r *exitRewriter) Flush() error {
+	if len(r.buf) > 0 {
+		_, err := r.w.Write(r.buf)
+		r.buf = r.buf[:0]
+		return err
+	}
+	return nil
 }

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -223,9 +223,12 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	rw := &exitRewriter{w: os.Stdout}
 	_, copyErr := io.Copy(rw, ptmx)
 
+	// Close the PTY master so the child receives SIGHUP if it's still running
+	// (e.g. when io.Copy returned early due to a downstream write error).
+	_ = ptmx.Close()
+
 	err = cmd.Wait()
 	closeWaitDone()
-	_ = ptmx.Close()
 	// PTY reads commonly return EIO when the slave side closes on normal
 	// process exit — treat it as expected EOF. Surface other copy errors
 	// only when the process itself exited cleanly.

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -159,13 +159,19 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 
 	// Forward terminal resizes to the PTY.
 	sigCh := make(chan os.Signal, 1)
+	sigDone := make(chan struct{})
 	signal.Notify(sigCh, syscall.SIGWINCH)
 	go func() {
+		defer close(sigDone)
 		for range sigCh {
 			_ = pty.InheritSize(os.Stdin, ptmx)
 		}
 	}()
-	defer signal.Stop(sigCh)
+	defer func() {
+		signal.Stop(sigCh)
+		close(sigCh)
+		<-sigDone
+	}()
 	_ = pty.InheritSize(os.Stdin, ptmx)
 
 	// Raw mode so keystrokes pass through verbatim (Ctrl-C, arrows, etc.).
@@ -211,15 +217,6 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 		return fmt.Errorf("set raw terminal: %w", err)
 	}
 	defer func() { _ = term.Restore(fd, oldState) }()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGWINCH)
-	go func() {
-		for range sigCh {
-			// Terminal resize is forwarded by the exec stream automatically.
-		}
-	}()
-	defer signal.Stop(sigCh)
 
 	serverURL := fmt.Sprintf("http://localhost:%d", workspace.BasePort)
 	rw := &exitRewriter{w: os.Stdout}

--- a/internal/cmd/attach_test.go
+++ b/internal/cmd/attach_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -21,6 +22,8 @@ func TestAttachHostArgs(t *testing.T) {
 		serverURL string
 		password  string
 		dir       string
+		session   string
+		cont      bool
 		want      []string
 	}{
 		{
@@ -51,13 +54,38 @@ func TestAttachHostArgs(t *testing.T) {
 			dir:       "/path",
 			want:      []string{"attach", "http://localhost:4096", "--password", "secret", "--dir", "/path"},
 		},
+		{
+			name:      "with session",
+			serverURL: "http://localhost:4096",
+			password:  "",
+			dir:       "",
+			session:   "ses_abc123",
+			want:      []string{"attach", "http://localhost:4096", "--session", "ses_abc123"},
+		},
+		{
+			name:      "with continue",
+			serverURL: "http://localhost:4096",
+			password:  "",
+			dir:       "",
+			cont:      true,
+			want:      []string{"attach", "http://localhost:4096", "--continue"},
+		},
+		{
+			name:      "all flags",
+			serverURL: "http://localhost:4096",
+			password:  "secret",
+			dir:       "/path",
+			session:   "ses_abc123",
+			cont:      true,
+			want:      []string{"attach", "http://localhost:4096", "--password", "secret", "--dir", "/path", "--session", "ses_abc123", "--continue"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := attachHostArgs(tt.serverURL, tt.password, tt.dir)
+			got := attachHostArgs(tt.serverURL, tt.password, tt.dir, tt.session, tt.cont)
 			if !slicesEqual(got, tt.want) {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
@@ -72,6 +100,8 @@ func TestAttachExecArgs(t *testing.T) {
 		name      string
 		serverURL string
 		dir       string
+		session   string
+		cont      bool
 		want      []string
 	}{
 		{
@@ -86,13 +116,35 @@ func TestAttachExecArgs(t *testing.T) {
 			dir:       "/home/user/project",
 			want:      []string{"opencode", "attach", "http://localhost:4096", "--dir", "/home/user/project"},
 		},
+		{
+			name:      "with session",
+			serverURL: "http://localhost:4096",
+			dir:       "",
+			session:   "ses_abc123",
+			want:      []string{"opencode", "attach", "http://localhost:4096", "--session", "ses_abc123"},
+		},
+		{
+			name:      "with continue",
+			serverURL: "http://localhost:4096",
+			dir:       "",
+			cont:      true,
+			want:      []string{"opencode", "attach", "http://localhost:4096", "--continue"},
+		},
+		{
+			name:      "all flags",
+			serverURL: "http://localhost:4096",
+			dir:       "/path",
+			session:   "ses_abc123",
+			cont:      true,
+			want:      []string{"opencode", "attach", "http://localhost:4096", "--dir", "/path", "--session", "ses_abc123", "--continue"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := attachExecArgs(tt.serverURL, tt.dir)
+			got := attachExecArgs(tt.serverURL, tt.dir, tt.session, tt.cont)
 			if !slicesEqual(got, tt.want) {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
@@ -450,4 +502,78 @@ func countEnvKey(env []string, key string) int {
 		}
 	}
 	return count
+}
+
+func TestExitRewriter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		writes []string
+		want   string
+	}{
+		{
+			name:   "no match passes through",
+			writes: []string{"hello world\n"},
+			want:   "hello world\n",
+		},
+		{
+			name:   "replaces opencode -s in single write",
+			writes: []string{"  Continue  opencode -s ses_abc123\n"},
+			want:   "  Continue  jailoc -s ses_abc123\n",
+		},
+		{
+			name:   "replaces when split across writes",
+			writes: []string{"  Continue  open", "code -s ses_abc123\n"},
+			want:   "  Continue  jailoc -s ses_abc123\n",
+		},
+		{
+			name:   "replaces when split mid-pattern",
+			writes: []string{"opencode", " -s ses_x\n"},
+			want:   "jailoc -s ses_x\n",
+		},
+		{
+			name:   "multiple replacements",
+			writes: []string{"opencode -s a\nopencode -s b\n"},
+			want:   "jailoc -s a\njailoc -s b\n",
+		},
+		{
+			name:   "partial match at end flushed without replacement",
+			writes: []string{"trailing opencode"},
+			want:   "trailing opencode",
+		},
+		{
+			name:   "empty write",
+			writes: []string{""},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			rw := &exitRewriter{w: &buf}
+
+			for _, w := range tt.writes {
+				n, err := rw.Write([]byte(w))
+				if err != nil {
+					t.Fatalf("Write(%q): %v", w, err)
+				}
+				if n != len(w) {
+					t.Fatalf("Write(%q) returned %d, want %d", w, n, len(w))
+				}
+			}
+
+			if err := rw.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+
+			got := buf.String()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,6 +28,8 @@ var workspaceFlag string
 var workspaceExplicit bool
 var appVersion string
 var remoteFlag, execFlag bool
+var sessionFlag string
+var continueFlag bool
 
 var rootCmd = &cobra.Command{
 	Use:          "jailoc [path]",
@@ -162,10 +164,10 @@ var rootCmd = &cobra.Command{
 		switch mode {
 		case config.ModeExec:
 			_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (exec mode)...\n", ws.Name)
-			attachErr = attachExec(attachCtx, client, targetPath)
+			attachErr = attachExec(attachCtx, client, targetPath, sessionFlag, continueFlag)
 		default:
 			_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
-			attachErr = attachOnHost(attachCtx, ws, targetPath, cfg.PasswordMode)
+			attachErr = attachOnHost(attachCtx, ws, targetPath, cfg.PasswordMode, sessionFlag, continueFlag)
 		}
 		if attachErr != nil {
 			return fmt.Errorf("attach to workspace %q: %w", ws.Name, attachErr)
@@ -180,6 +182,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&remoteFlag, "remote", false, "Use remote mode (host-side opencode attach)")
 	rootCmd.PersistentFlags().BoolVar(&execFlag, "exec", false, "Use exec mode (docker exec opencode inside container)")
 	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
+	rootCmd.Flags().StringVarP(&sessionFlag, "session", "s", "", "session ID to continue")
+	rootCmd.Flags().BoolVarP(&continueFlag, "continue", "c", false, "continue the last session")
 	rootCmd.MarkFlagsMutuallyExclusive("remote", "exec")
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -185,6 +185,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&sessionFlag, "session", "s", "", "session ID to continue")
 	rootCmd.Flags().BoolVarP(&continueFlag, "continue", "c", false, "continue the last session")
 	rootCmd.MarkFlagsMutuallyExclusive("remote", "exec")
+	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")
 }
 
 // resolveTargetPath returns the absolute path from a positional argument.


### PR DESCRIPTION
## Summary

- Add `-s`/`--session` and `-c`/`--continue` flags to `jailoc` root command, forwarding them to `opencode attach` in both remote and exec modes
- Replace `opencode -s` with `jailoc -s` in stdout via streaming `exitRewriter` so the exit screen shows the correct continuation command
- Tests for arg builders and the rewriter (single write, split across writes, multiple replacements, partial match flush)

Closes #114