### PR TITLE
fix(config): mount OpenCode config directories read-write

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Manage sandboxed Docker Compose environments for headless OpenCode coding agents
 
 ## What is this?
 
-`jailoc` wraps OpenCode agents in isolated Docker containers so they can run autonomously without touching your host system. Each workspace gets its own sandboxed environment with network isolation that blocks private networks by default, letting you control exactly which internal services the agent can reach. You configure which directories to mount as workspaces, which hosts to allowlist, and the agent runs inside with your OpenCode config available read-only.
+`jailoc` wraps OpenCode agents in isolated Docker containers so they can run autonomously without touching your host system. Each workspace gets its own sandboxed environment with network isolation that blocks private networks by default, letting you control exactly which internal services the agent can reach. You configure which directories to mount as workspaces, which hosts to allowlist, and the agent runs inside with your OpenCode config available read-write.
 
 ## Why jailoc
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Manage sandboxed Docker Compose environments for headless OpenCode coding agents
 
 ## What is this?
 
-`jailoc` wraps OpenCode agents in isolated Docker containers so they can run autonomously without touching your host system. Each workspace gets its own sandboxed environment with network isolation that blocks private networks by default, letting you control exactly which internal services the agent can reach. You configure which directories to mount as workspaces, which hosts to allowlist, and the agent runs inside with your OpenCode config available read-write.
+`jailoc` wraps OpenCode agents in isolated Docker containers so they can run autonomously, isolated from your host system except for explicitly mounted paths. Each workspace gets its own sandboxed environment with network isolation that blocks private networks by default, letting you control exactly which internal services the agent can reach. You configure which directories to mount as workspaces, which hosts to allowlist, and the agent runs inside with your OpenCode config available read-write.
 
 ## Why jailoc
 

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -26,7 +26,7 @@ flowchart TB
     dind -.- net
 ```
 
-The **opencode container** is where the agent lives. It runs `opencode serve` as UID 1000 (a non-root user named `agent`), exposes a port bound to `127.0.0.1` on the host for attaching a terminal (not reachable from LAN or VPN), and has your workspace paths mounted read-write. Host directories are mounted into the container via configurable bind mounts — by default, your OpenCode configuration (read-only), session transcripts, and agent tooling directories. See [How-to: Configure mounts](../how-to/workspace-configuration.md#configure-mounts) for customization.
+The **opencode container** is where the agent lives. It runs `opencode serve` as UID 1000 (a non-root user named `agent`), exposes a port bound to `127.0.0.1` on the host for attaching a terminal (not reachable from LAN or VPN), and has your workspace paths mounted read-write. Host directories are mounted into the container via configurable bind mounts — by default, your OpenCode configuration (read-write), session transcripts, and agent tooling directories. See [How-to: Configure mounts](../how-to/workspace-configuration.md#configure-mounts) for customization.
 
 The opencode container runs with configurable resource limits. The `cpu` (default 2 cores) and `memory` (default 4 GB) settings control how much of the host's resources the container can consume, and are configurable per workspace via the TOML config. Other resource limits — `pids_limit` (256) and `mem_reservation` (512 MB) — are fixed and not configurable. Resource limit changes take effect on the next `jailoc up` invocation; running containers are not affected until restarted.
 

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -45,7 +45,7 @@ The opencode container mounts several things at startup:
 | Mount | Direction | Purpose |
 |-------|-----------|---------|
 | Workspace paths | read-write | The directories the agent is working in |
-| Configurable mounts | per-mount | Host directories mounted into the container, controlled by the `mounts` config field. Defaults include OpenCode configuration (ro), session transcripts (rw), and agent tooling (ro). See [Configuration Reference](../reference/configuration.md#mounts) for the full list and merge rules. |
+| Configurable mounts | per-mount | Host directories mounted into the container, controlled by the `mounts` config field. Defaults include OpenCode configuration (rw — the agent needs write access to persist settings, install tools, and update its own configuration), session transcripts (rw), and agent tooling (ro). See [Configuration Reference](../reference/configuration.md#mounts) for the full list and merge rules. |
 | `/etc/jailoc` | read-only | jailoc's own runtime config, including allowed hosts |
 | SSH agent socket | read-write | Host SSH agent forwarded into the container (when `ssh_auth_sock = true`). Also mounts `~/.ssh/known_hosts` read-only for host key verification. |
 | `~/.gitconfig` | read-only | Host Git configuration (when `git_config = true`, the default) |

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -13,7 +13,7 @@ flowchart TB
     subgraph oc["opencode"]
       direction TB
       oc_uid["UID 1000 (agent)<br>opencode serve :4096<br>published to host 127.0.0.1:PORT"]
-      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/oc (ro)<br>~/.claude/transcripts (rw)<br>/etc/jailoc (ro)"]
+      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/oc (rw)<br>~/.claude/transcripts (rw)<br>/etc/jailoc (ro)"]
     end
     subgraph dind["dind (privileged)"]
       direction TB

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -13,7 +13,7 @@ flowchart TB
     subgraph oc["opencode"]
       direction TB
       oc_uid["UID 1000 (agent)<br>opencode serve :4096<br>published to host 127.0.0.1:PORT"]
-      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/oc (rw)<br>~/.claude/transcripts (rw)<br>/etc/jailoc (ro)"]
+      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/opencode (rw)<br>~/.opencode (rw)<br>~/.claude/transcripts (rw)<br>/etc/jailoc (ro)"]
     end
     subgraph dind["dind (privileged)"]
       direction TB

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -13,7 +13,7 @@ flowchart TB
     subgraph oc["opencode"]
       direction TB
       oc_uid["UID 1000 (agent)<br>opencode serve :4096<br>published to host 127.0.0.1:PORT"]
-      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/opencode (rw)<br>~/.opencode (rw)<br>~/.claude/transcripts (rw)<br>/etc/jailoc (ro)"]
+      oc_mounts["Mounts:<br>paths/* (rw)<br>~/.config/opencode (rw)<br>~/.opencode (rw)<br>~/.claude/transcripts (rw)<br>~/.agents (ro)<br>/etc/jailoc (ro)"]
     end
     subgraph dind["dind (privileged)"]
       direction TB

--- a/docs/explanation/network-isolation.md
+++ b/docs/explanation/network-isolation.md
@@ -50,7 +50,7 @@ The dind container's allowed hosts and networks are configured from the same `/e
 
 - The agent runs as an unprivileged user (UID 1000) with all Linux capabilities dropped and `no_new_privs` set
 - Resource limits apply: 4 GB RAM, 2 CPUs, 256 PIDs
-- OpenCode configuration directories are mounted read-only — the agent can read your settings but cannot modify them on the host
+- OpenCode configuration directories are mounted read-write — the agent can read and modify your settings
 - The agent's data volume (SQLite history, auth tokens) is a named Docker volume, completely separate from your host's `~/.local/share/opencode`
 - The agent gets its own Docker daemon through dind — it never touches the host Docker socket, so containers it starts cannot escape to the host
 - Network egress to private and internal ranges is blocked by iptables

--- a/docs/explanation/network-isolation.md
+++ b/docs/explanation/network-isolation.md
@@ -50,7 +50,7 @@ The dind container's allowed hosts and networks are configured from the same `/e
 
 - The agent runs as an unprivileged user (UID 1000) with all Linux capabilities dropped and `no_new_privs` set
 - Resource limits apply: 4 GB RAM, 2 CPUs, 256 PIDs
-- OpenCode configuration directories are mounted read-write — the agent can read and modify your settings
+- OpenCode configuration directories are mounted read-write — the agent needs write access to persist settings changes, install tools and MCPs, and update its own configuration at runtime
 - The agent's data volume (SQLite history, auth tokens) is a named Docker volume, completely separate from your host's `~/.local/share/opencode`
 - The agent gets its own Docker daemon through dind — it never touches the host Docker socket, so containers it starts cannot escape to the host
 - Network egress to private and internal ranges is blocked by iptables

--- a/docs/explanation/threat-model.md
+++ b/docs/explanation/threat-model.md
@@ -44,7 +44,7 @@ jailoc's isolation model targets two legs of the trifecta:
 
 **Restricting external communication.** The [iptables rules](network-isolation.md) block egress to all private network ranges (RFC 1918, link-local, CGNAT). Even if an attacker's instructions reach the agent, the agent cannot send stolen data to internal infrastructure. Public internet egress remains open (the agent needs it to function), but the internal network — where the most sensitive services live — is unreachable. The DinD sidecar runs a rootless Docker daemon, so inner containers — even those started with `--privileged` or `--network=host` — are subject to the same iptables restrictions and cannot bypass them.
 
-**Limiting private data access.** The agent only sees directories explicitly mounted in the workspace configuration. Host credentials, SSH keys, and unrelated project directories are not available inside the container. OpenCode configuration is mounted read-only. The agent runs as an unprivileged user with dropped capabilities and `no_new_privs`.
+**Limiting private data access.** The agent only sees directories explicitly mounted in the workspace configuration. Host credentials, SSH keys, and unrelated project directories are not available inside the container. OpenCode configuration is mounted read-write. The agent runs as an unprivileged user with dropped capabilities and `no_new_privs`.
 
 These controls do not eliminate prompt injection. They reduce the blast radius by ensuring that even a successfully manipulated agent cannot reach internal services or access data outside its designated workspace.
 

--- a/docs/how-to/workspace-configuration.md
+++ b/docs/how-to/workspace-configuration.md
@@ -212,7 +212,7 @@ To remove a default mount, set an empty host source for that container path:
 ```toml
 [workspaces.my-project]
 paths = ["/home/you/projects/my-project"]
-mounts = [":/home/agent/.opencode:ro"]
+mounts = [":/home/agent/.opencode"]
 ```
 
 This removes the `~/.opencode` mount for the `my-project` workspace.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -251,6 +251,8 @@ Environment variables from multiple sources are merged in this order (later entr
 |---|---|---|
 | `/home/agent/.config/opencode` | `~/.config/opencode` | `rw` |
 | `/home/agent/.opencode` | `~/.opencode` | `rw` |
+
+OpenCode configuration directories are mounted read-write because the agent needs write access to persist settings changes, install tools and MCPs, and update its own configuration at runtime.
 | `/home/agent/.claude/transcripts` | `~/.claude/transcripts` | `rw` |
 | `/home/agent/.agents` | `~/.agents` | `ro` |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -95,7 +95,7 @@ Each workspace is declared as a TOML table under `[workspaces]`, keyed by name.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `paths` | string[] | (required) | Directories bind-mounted into the container at their original absolute paths. The first path becomes the container's working directory. Supports `~` expansion. |
-| `mounts` | string[] | `[]` | Bind mounts for this workspace. Format: `host:container[:mode]` — mode is `ro` or `rw` (default `rw`). An empty host source (e.g. `":/home/agent/.opencode:ro"`) removes a default mount matching the container path. Container destinations under `/home/agent/...` are allowed (unlike `paths`); see [mounts validation](#mounts) for the full list of forbidden container prefixes. |
+| `mounts` | string[] | `[]` | Bind mounts for this workspace. Format: `host:container[:mode]` — mode is `ro` or `rw` (default `rw`). An empty host source (e.g. `":/home/agent/.opencode"`) removes a default mount matching the container path. Container destinations under `/home/agent/...` are allowed (unlike `paths`); see [mounts validation](#mounts) for the full list of forbidden container prefixes. |
 | `allowed_hosts` | string[] | `[]` | Hostnames resolved at container start and added as iptables `ACCEPT` rules before the private-range `DROP` rules. |
 | `allowed_networks` | string[] | `[]` | CIDR ranges explicitly allowed through the container firewall. |
 | `image` | string | (none) | Pre-built Docker image to use directly for this workspace, bypassing all build steps. Compose pulls the image natively at startup. Cannot be combined with `dockerfile` or `build_context`. |
@@ -251,10 +251,10 @@ Environment variables from multiple sources are merged in this order (later entr
 |---|---|---|
 | `/home/agent/.config/opencode` | `~/.config/opencode` | `rw` |
 | `/home/agent/.opencode` | `~/.opencode` | `rw` |
-
-OpenCode configuration directories are mounted read-write because the agent needs write access to persist settings changes, install tools and MCPs, and update its own configuration at runtime.
 | `/home/agent/.claude/transcripts` | `~/.claude/transcripts` | `rw` |
 | `/home/agent/.agents` | `~/.agents` | `ro` |
+
+OpenCode configuration directories are mounted read-write because the agent needs write access to persist settings changes, install tools and MCPs, and update its own configuration at runtime.
 
 `ssh_auth_sock`, `git_config`, `expose_port`, and `enable_docker` inherit from `[defaults]` when not set in the workspace. When set explicitly in a workspace, the workspace value takes precedence. `git_config`, `expose_port`, and `enable_docker` fall back to `true` when neither the workspace nor defaults set it.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -249,8 +249,8 @@ Environment variables from multiple sources are merged in this order (later entr
 
 | Container path | Host source | Mode |
 |---|---|---|
-| `/home/agent/.config/opencode` | `~/.config/opencode` | `ro` |
-| `/home/agent/.opencode` | `~/.opencode` | `ro` |
+| `/home/agent/.config/opencode` | `~/.config/opencode` | `rw` |
+| `/home/agent/.opencode` | `~/.opencode` | `rw` |
 | `/home/agent/.claude/transcripts` | `~/.claude/transcripts` | `rw` |
 | `/home/agent/.agents` | `~/.agents` | `ro` |
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -69,7 +69,7 @@ jailoc down     # stop and remove the workspace containers
 
 When the workspace is up, two containers are active on an isolated Docker network:
 
-- **opencode container** — runs `opencode serve` as UID 1000 with your workspace paths mounted read-write and your OpenCode config mounted read-only.
+- **opencode container** — runs `opencode serve` as UID 1000 with your workspace paths mounted read-write and your OpenCode config mounted read-write.
 - **dind container** — provides a privileged Docker daemon over TLS on port 2376, so the agent can build and run containers if needed.
 
 The entrypoint script sets iptables rules that block private network ranges by default before dropping privileges. The agent can reach the internet, but not your internal network, unless you explicitly allow it.

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -785,10 +785,10 @@ func TestGenerateComposeMountsFromParams(t *testing.T) {
 		Port:          4800,
 		Image:         "ghcr.io/seznam/jailoc:test",
 		Paths:         []string{"/tmp/work"},
-	Mounts: []string{
-		"/home/user/.config/opencode:/home/agent/.config/opencode:rw",
-		"/home/user/.agents:/home/agent/.agents:ro",
-	},
+		Mounts: []string{
+			"/home/user/.config/opencode:/home/agent/.config/opencode:rw",
+			"/home/user/.agents:/home/agent/.agents:ro",
+		},
 		CPU:    2.0,
 		Memory: "4g",
 	}

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -786,8 +786,8 @@ func TestGenerateComposeMountsFromParams(t *testing.T) {
 		Image:         "ghcr.io/seznam/jailoc:test",
 		Paths:         []string{"/tmp/work"},
 		Mounts: []string{
-			"/home/user/.config/opencode:/home/agent/.config/opencode:ro",
-			"/home/user/.agents:/home/agent/.agents:ro",
+		"/home/user/.config/opencode:/home/agent/.config/opencode:rw",
+		"/home/user/.agents:/home/agent/.agents:ro",
 		},
 		CPU:    2.0,
 		Memory: "4g",
@@ -799,13 +799,13 @@ func TestGenerateComposeMountsFromParams(t *testing.T) {
 	}
 
 	rendered := string(out)
-	assertContains(t, rendered, "/home/user/.config/opencode:/home/agent/.config/opencode:ro")
+	assertContains(t, rendered, "/home/user/.config/opencode:/home/agent/.config/opencode:rw")
 	assertContains(t, rendered, "/home/user/.agents:/home/agent/.agents:ro")
 
-	if strings.Contains(rendered, "${HOME}/.config/opencode:/home/agent/.config/opencode:ro") {
+	if strings.Contains(rendered, "${HOME}/.config/opencode:/home/agent/.config/opencode:rw") {
 		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
 	}
-	if strings.Contains(rendered, "${HOME}/.opencode:/home/agent/.opencode:ro") {
+	if strings.Contains(rendered, "${HOME}/.opencode:/home/agent/.opencode:rw") {
 		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
 	}
 	if strings.Contains(rendered, "${HOME}/.claude/transcripts:/home/agent/.claude/transcripts") {

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -785,10 +785,10 @@ func TestGenerateComposeMountsFromParams(t *testing.T) {
 		Port:          4800,
 		Image:         "ghcr.io/seznam/jailoc:test",
 		Paths:         []string{"/tmp/work"},
-		Mounts: []string{
+	Mounts: []string{
 		"/home/user/.config/opencode:/home/agent/.config/opencode:rw",
 		"/home/user/.agents:/home/agent/.agents:ro",
-		},
+	},
 		CPU:    2.0,
 		Memory: "4g",
 	}
@@ -802,10 +802,10 @@ func TestGenerateComposeMountsFromParams(t *testing.T) {
 	assertContains(t, rendered, "/home/user/.config/opencode:/home/agent/.config/opencode:rw")
 	assertContains(t, rendered, "/home/user/.agents:/home/agent/.agents:ro")
 
-	if strings.Contains(rendered, "${HOME}/.config/opencode:/home/agent/.config/opencode:rw") {
+	if strings.Contains(rendered, "${HOME}/.config/opencode:/home/agent/.config/opencode") {
 		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
 	}
-	if strings.Contains(rendered, "${HOME}/.opencode:/home/agent/.opencode:rw") {
+	if strings.Contains(rendered, "${HOME}/.opencode:/home/agent/.opencode") {
 		t.Fatalf("expected no hardcoded OC mounts in template output, got:\n%s", rendered)
 	}
 	if strings.Contains(rendered, "${HOME}/.claude/transcripts:/home/agent/.claude/transcripts") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ const (
 # image = ""
 # env = ["KEY=VALUE"]
 # env_file = ["/path/to/.env"]
-# mounts = ["~/.config/opencode:/home/agent/.config/opencode:ro"]
+# mounts = ["~/.config/opencode:/home/agent/.config/opencode:rw"]
 # allowed_hosts = ["example.com"]
 # allowed_networks = ["10.0.0.0/8"]
 # ssh_auth_sock = false
@@ -48,7 +48,7 @@ paths = []
 # allowed_networks = []
 # env = ["KEY=VALUE"]
 # env_file = ["/path/to/.env"]
-# mounts = ["~/.config/opencode:/home/agent/.config/opencode:ro"]
+# mounts = ["~/.config/opencode:/home/agent/.config/opencode:rw"]
 # build_context = ""
 # dockerfile = ""
 # ssh_auth_sock = false
@@ -138,8 +138,8 @@ var forbiddenMountHostPaths = []string{
 }
 
 var DefaultMounts = []string{
-	"~/.config/opencode:/home/agent/.config/opencode:ro",
-	"~/.opencode:/home/agent/.opencode:ro",
+	"~/.config/opencode:/home/agent/.config/opencode:rw",
+	"~/.opencode:/home/agent/.opencode:rw",
 	"~/.claude/transcripts:/home/agent/.claude/transcripts:rw",
 	"~/.agents:/home/agent/.agents:ro",
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2370,8 +2370,8 @@ func TestMergeMounts(t *testing.T) {
 				DefaultMounts,
 			},
 			expected: []string{
-				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
-				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:rw",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:rw",
 				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 			},
@@ -2384,7 +2384,7 @@ func TestMergeMounts(t *testing.T) {
 			},
 			expected: []string{
 				filepath.Join(home, "cfg") + ":/home/agent/.config/opencode:rw",
-				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:rw",
 				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 			},
@@ -2396,7 +2396,7 @@ func TestMergeMounts(t *testing.T) {
 				{":/home/agent/.opencode"},
 			},
 			expected: []string{
-				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:rw",
 				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 			},
@@ -2408,8 +2408,8 @@ func TestMergeMounts(t *testing.T) {
 				{"~/my-data:/workspace/data:rw"},
 			},
 			expected: []string{
-				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
-				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:rw",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:rw",
 				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 				filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 				filepath.Join(home, "my-data") + ":/workspace/data:rw",
@@ -2424,7 +2424,7 @@ func TestMergeMounts(t *testing.T) {
 			},
 			expected: []string{
 				filepath.Join(home, "cfg") + ":/home/agent/.config/opencode:rw",
-				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+				filepath.Join(home, ".opencode") + ":/home/agent/.opencode:rw",
 				filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 				filepath.Join(home, "y") + ":/x:ro",
 			},

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1220,8 +1220,8 @@ func TestResolveMountsDefault(t *testing.T) {
 	}
 
 	want := []string{
-		filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
-		filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+		filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:rw",
+		filepath.Join(home, ".opencode") + ":/home/agent/.opencode:rw",
 		filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 		filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 	}
@@ -1251,7 +1251,7 @@ func TestResolveMountsOverride(t *testing.T) {
 
 	want := []string{
 		filepath.Join(home, "custom-opencode") + ":/home/agent/.config/opencode:rw",
-		filepath.Join(home, ".opencode") + ":/home/agent/.opencode:ro",
+		filepath.Join(home, ".opencode") + ":/home/agent/.opencode:rw",
 		filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 		filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 	}
@@ -1280,7 +1280,7 @@ func TestResolveMountsRemoval(t *testing.T) {
 	}
 
 	want := []string{
-		filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:ro",
+		filepath.Join(home, ".config", "opencode") + ":/home/agent/.config/opencode:rw",
 		filepath.Join(home, ".claude", "transcripts") + ":/home/agent/.claude/transcripts:rw",
 		filepath.Join(home, ".agents") + ":/home/agent/.agents:ro",
 	}


### PR DESCRIPTION
## Summary

- Change default mounts for `~/.config/opencode` and `~/.opencode` from `:ro` to `:rw` — OpenCode now requires write access to its config directories (https://github.com/anomalyco/opencode/issues/23040)
- Update all docs (README, tutorials, reference, explanation) to reflect read-write mount