### PR TITLE
feat(attach): show loading indicator until OpenCode renders

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
             ];
           };
 
-          vendorHash = "sha256-FyttN9MPt91ryMFdYFYhjFAyARAiO9TQYtkqjuecWhw=";
+          vendorHash = "sha256-wMcVcpoYYqlV09H5rb/R7l4B8H8a9aKeD2f5bgkZMK4=";
 
           subPackages = [ "cmd/jailoc" ];
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/moby/moby/api v1.54.1
 	github.com/moby/term v0.5.2
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/term v0.42.0
 )
@@ -38,6 +39,7 @@ require (
 	github.com/containerd/ttrpc v1.2.8 // indirect
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/buildx v0.33.0 // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
@@ -91,6 +93,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -231,7 +231,7 @@ func attachOnHost(ctx context.Context, client *docker.Client, ws *workspace.Reso
 		status = os.Stdout
 	}
 	logReader, logCancel := startLogStream(ctx, client, status)
-	sw := newStartupWriter(rw, status, startupTimeout, logReader, logCancel)
+	sw := newStartupWriter(rw, status, slowStartWarning, logReader, logCancel)
 	_, copyErr := io.Copy(sw, ptmx)
 
 	// Close the PTY master so the child receives SIGHUP if it's still running
@@ -268,7 +268,7 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 		status = os.Stdout
 	}
 	logReader, logCancel := startLogStream(ctx, client, status)
-	sw := newStartupWriter(rw, status, startupTimeout, logReader, logCancel)
+	sw := newStartupWriter(rw, status, slowStartWarning, logReader, logCancel)
 	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, sw, os.Stderr)
 	sw.Close()
 	if ferr := rw.Flush(); ferr != nil && err == nil {
@@ -280,7 +280,7 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 const (
 	attachPollInterval = 500 * time.Millisecond
 	attachWaitDelay    = 2 * time.Second
-	startupTimeout     = 5 * time.Second
+	slowStartWarning   = 10 * time.Second
 )
 
 var errUnhealthy = errors.New("opencode process unhealthy inside container")

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -227,7 +227,7 @@ func attachOnHost(ctx context.Context, client *docker.Client, ws *workspace.Reso
 
 	rw := &exitRewriter{w: os.Stdout}
 	var status io.Writer
-	if term.IsTerminal(int(os.Stdout.Fd())) {
+	if term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115: uintptr→int is safe for file descriptors
 		status = os.Stdout
 	}
 	var logReader io.Reader
@@ -274,7 +274,7 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 	serverURL := fmt.Sprintf("http://localhost:%d", workspace.BasePort)
 	rw := &exitRewriter{w: os.Stdout}
 	var status io.Writer
-	if term.IsTerminal(int(os.Stdout.Fd())) {
+	if term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115: uintptr→int is safe for file descriptors
 		status = os.Stdout
 	}
 	var logReader io.Reader

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -124,7 +124,7 @@ func envWithOverrides(base []string, overrides ...string) []string {
 	return append(filtered, overrides...)
 }
 
-func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passwordMode string, session string, cont bool) error {
+func attachOnHost(ctx context.Context, client *docker.Client, ws *workspace.Resolved, dir string, passwordMode string, session string, cont bool) error {
 	binary, err := config.ResolveBinary()
 	if err != nil {
 		return fmt.Errorf("resolve opencode binary: %w", err)
@@ -230,7 +230,16 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		status = os.Stdout
 	}
-	sw := newStartupWriter(rw, status, 5*time.Second)
+	var logReader io.Reader
+	var logCancel func()
+	if status != nil && client != nil {
+		pr, pw := io.Pipe()
+		logCtx, cancel := context.WithCancel(ctx)
+		logCancel = cancel
+		go func() { _ = client.StreamRecentLogs(logCtx, pw); _ = pw.Close() }()
+		logReader = pr
+	}
+	sw := newStartupWriter(rw, status, 5*time.Second, logReader, logCancel)
 	_, copyErr := io.Copy(sw, ptmx)
 
 	// Close the PTY master so the child receives SIGHUP if it's still running
@@ -268,7 +277,16 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		status = os.Stdout
 	}
-	sw := newStartupWriter(rw, status, 5*time.Second)
+	var logReader io.Reader
+	var logCancel func()
+	if status != nil && client != nil {
+		pr, pw := io.Pipe()
+		logCtx, cancel := context.WithCancel(ctx)
+		logCancel = cancel
+		go func() { _ = client.StreamRecentLogs(logCtx, pw); _ = pw.Close() }()
+		logReader = pr
+	}
+	sw := newStartupWriter(rw, status, 5*time.Second, logReader, logCancel)
 	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, sw, os.Stderr)
 	if cerr := sw.Close(); cerr != nil && err == nil {
 		err = fmt.Errorf("close startup writer: %w", cerr)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -226,7 +226,12 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	}()
 
 	rw := &exitRewriter{w: os.Stdout}
-	_, copyErr := io.Copy(rw, ptmx)
+	var status io.Writer
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		status = os.Stdout
+	}
+	sw := newStartupWriter(rw, status, 5*time.Second)
+	_, copyErr := io.Copy(sw, ptmx)
 
 	// Close the PTY master so the child receives SIGHUP if it's still running
 	// (e.g. when io.Copy returned early due to a downstream write error).
@@ -239,6 +244,9 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	// only when the process itself exited cleanly.
 	if copyErr != nil && err == nil && !errors.Is(copyErr, errEIO) {
 		err = fmt.Errorf("copy pty output: %w", copyErr)
+	}
+	if cerr := sw.Close(); cerr != nil && err == nil {
+		err = fmt.Errorf("close startup writer: %w", cerr)
 	}
 	if ferr := rw.Flush(); ferr != nil && err == nil {
 		err = fmt.Errorf("flush exit rewriter: %w", ferr)
@@ -256,7 +264,15 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 
 	serverURL := fmt.Sprintf("http://localhost:%d", workspace.BasePort)
 	rw := &exitRewriter{w: os.Stdout}
-	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, rw, os.Stderr)
+	var status io.Writer
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		status = os.Stdout
+	}
+	sw := newStartupWriter(rw, status, 5*time.Second)
+	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, sw, os.Stderr)
+	if cerr := sw.Close(); cerr != nil && err == nil {
+		err = fmt.Errorf("close startup writer: %w", cerr)
+	}
 	if ferr := rw.Flush(); ferr != nil && err == nil {
 		err = fmt.Errorf("flush exit rewriter: %w", ferr)
 	}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -231,7 +231,7 @@ func attachOnHost(ctx context.Context, client *docker.Client, ws *workspace.Reso
 		status = os.Stdout
 	}
 	logReader, logCancel := startLogStream(ctx, client, status)
-	sw := newStartupWriter(rw, status, 5*time.Second, logReader, logCancel)
+	sw := newStartupWriter(rw, status, startupTimeout, logReader, logCancel)
 	_, copyErr := io.Copy(sw, ptmx)
 
 	// Close the PTY master so the child receives SIGHUP if it's still running
@@ -246,9 +246,7 @@ func attachOnHost(ctx context.Context, client *docker.Client, ws *workspace.Reso
 	if copyErr != nil && err == nil && !errors.Is(copyErr, errEIO) {
 		err = fmt.Errorf("copy pty output: %w", copyErr)
 	}
-	if cerr := sw.Close(); cerr != nil && err == nil {
-		err = fmt.Errorf("close startup writer: %w", cerr)
-	}
+	sw.Close()
 	if ferr := rw.Flush(); ferr != nil && err == nil {
 		err = fmt.Errorf("flush exit rewriter: %w", ferr)
 	}
@@ -270,11 +268,9 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 		status = os.Stdout
 	}
 	logReader, logCancel := startLogStream(ctx, client, status)
-	sw := newStartupWriter(rw, status, 5*time.Second, logReader, logCancel)
+	sw := newStartupWriter(rw, status, startupTimeout, logReader, logCancel)
 	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, sw, os.Stderr)
-	if cerr := sw.Close(); cerr != nil && err == nil {
-		err = fmt.Errorf("close startup writer: %w", cerr)
-	}
+	sw.Close()
 	if ferr := rw.Flush(); ferr != nil && err == nil {
 		err = fmt.Errorf("flush exit rewriter: %w", ferr)
 	}
@@ -284,6 +280,7 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 const (
 	attachPollInterval = 500 * time.Millisecond
 	attachWaitDelay    = 2 * time.Second
+	startupTimeout     = 5 * time.Second
 )
 
 var errUnhealthy = errors.New("opencode process unhealthy inside container")

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -230,15 +230,7 @@ func attachOnHost(ctx context.Context, client *docker.Client, ws *workspace.Reso
 	if term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115: uintptr→int is safe for file descriptors
 		status = os.Stdout
 	}
-	var logReader io.Reader
-	var logCancel func()
-	if status != nil && client != nil {
-		pr, pw := io.Pipe()
-		logCtx, cancel := context.WithCancel(ctx)
-		logCancel = cancel
-		go func() { _ = client.StreamRecentLogs(logCtx, pw); _ = pw.Close() }()
-		logReader = pr
-	}
+	logReader, logCancel := startLogStream(ctx, client, status)
 	sw := newStartupWriter(rw, status, 5*time.Second, logReader, logCancel)
 	_, copyErr := io.Copy(sw, ptmx)
 
@@ -277,15 +269,7 @@ func attachExec(ctx context.Context, client *docker.Client, dir string, session 
 	if term.IsTerminal(int(os.Stdout.Fd())) { //nolint:gosec // G115: uintptr→int is safe for file descriptors
 		status = os.Stdout
 	}
-	var logReader io.Reader
-	var logCancel func()
-	if status != nil && client != nil {
-		pr, pw := io.Pipe()
-		logCtx, cancel := context.WithCancel(ctx)
-		logCancel = cancel
-		go func() { _ = client.StreamRecentLogs(logCtx, pw); _ = pw.Close() }()
-		logReader = pr
-	}
+	logReader, logCancel := startLogStream(ctx, client, status)
 	sw := newStartupWriter(rw, status, 5*time.Second, logReader, logCancel)
 	err = client.Exec(ctx, attachExecArgs(serverURL, dir, session, cont), execTUIConfigEnv("/etc/jailoc-tui.json"), os.Stdin, sw, os.Stderr)
 	if cerr := sw.Close(); cerr != nil && err == nil {
@@ -467,6 +451,16 @@ func (r *exitRewriter) Write(p []byte) (int, error) {
 	}
 
 	return len(p), nil
+}
+
+func startLogStream(ctx context.Context, client *docker.Client, status io.Writer) (io.Reader, func()) {
+	if status == nil || client == nil {
+		return nil, nil
+	}
+	logPR, logPW := io.Pipe()
+	logCtx, cancel := context.WithCancel(ctx)
+	go func() { _ = client.StreamRecentLogs(logCtx, logPW); _ = logPW.Close() }()
+	return logPR, cancel
 }
 
 // Flush writes any buffered partial-match bytes to the underlying writer.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -167,7 +167,7 @@ var rootCmd = &cobra.Command{
 			attachErr = attachExec(attachCtx, client, targetPath, sessionFlag, continueFlag)
 		default:
 			_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
-			attachErr = attachOnHost(attachCtx, ws, targetPath, cfg.PasswordMode, sessionFlag, continueFlag)
+			attachErr = attachOnHost(attachCtx, client, ws, targetPath, cfg.PasswordMode, sessionFlag, continueFlag)
 			if errors.Is(attachErr, errPTYUnsupported) {
 				if remoteFlag {
 					return fmt.Errorf("remote mode requires PTY support, which is not available on this platform; use --exec instead")

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -49,7 +49,10 @@ func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration, logR
 	sw.timer = time.AfterFunc(timeout, func() {
 		sw.mu.Lock()
 		defer sw.mu.Unlock()
-		sw.activate()
+		if sw.ready {
+			return
+		}
+		_, _ = fmt.Fprintf(sw.status, "\x1b[2K\rOpenCode is taking unusually long — run 'jailoc logs' to check")
 	})
 	if logReader != nil {
 		sw.logDone = make(chan struct{})

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 )
@@ -15,19 +18,22 @@ var (
 )
 
 type startupWriter struct {
-	w       io.Writer
-	status  io.Writer
-	buf     []byte
-	overlap []byte
-	ready   bool
-	altSeen bool
-	timer   *time.Timer
-	mu      sync.Mutex
-	timeout time.Duration
+	w         io.Writer
+	status    io.Writer
+	logReader io.Reader
+	logCancel func()
+	logDone   chan struct{}
+	buf       []byte
+	overlap   []byte
+	ready     bool
+	altSeen   bool
+	timer     *time.Timer
+	mu        sync.Mutex
+	timeout   time.Duration
 }
 
-func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration) *startupWriter {
-	sw := &startupWriter{w: w, status: status, timeout: timeout}
+func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration, logReader io.Reader, logCancel func()) *startupWriter {
+	sw := &startupWriter{w: w, status: status, timeout: timeout, logReader: logReader, logCancel: logCancel}
 	if status == nil {
 		sw.ready = true
 		return sw
@@ -39,6 +45,10 @@ func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration) *sta
 		defer sw.mu.Unlock()
 		sw.activate()
 	})
+	if logReader != nil {
+		sw.logDone = make(chan struct{})
+		go sw.readLogs()
+	}
 
 	return sw
 }
@@ -79,6 +89,26 @@ func (s *startupWriter) activate() {
 		return
 	}
 
+	logCancel := s.logCancel
+	s.logCancel = nil
+	logDone := s.logDone
+
+	if logCancel != nil {
+		logCancel()
+	}
+
+	if logDone != nil {
+		s.mu.Unlock()
+		select {
+		case <-logDone:
+		case <-time.After(time.Second):
+		}
+		s.mu.Lock()
+		if s.ready {
+			return
+		}
+	}
+
 	s.ready = true
 	if s.timer != nil {
 		s.timer.Stop()
@@ -100,4 +130,62 @@ func (s *startupWriter) Close() error {
 
 	s.activate()
 	return nil
+}
+
+func (s *startupWriter) readLogs() {
+	defer close(s.logDone)
+
+	scanner := bufio.NewScanner(s.logReader)
+	var lastUpdate time.Time
+
+	for scanner.Scan() {
+		msg := extractLogfmtMsg(scanner.Text())
+		if msg == "" {
+			continue
+		}
+
+		if len(msg) > 80 {
+			msg = msg[:80]
+		}
+
+		s.mu.Lock()
+		ready := s.ready
+		s.mu.Unlock()
+		if ready {
+			break
+		}
+
+		if time.Since(lastUpdate) < 100*time.Millisecond {
+			continue
+		}
+
+		_, _ = fmt.Fprintf(s.status, "\x1b[2K\r%s", msg)
+		lastUpdate = time.Now()
+	}
+}
+
+// extractLogfmtMsg extracts the value of the msg= field from a logfmt-formatted line.
+// Returns empty string if no msg= field is found or the value is empty.
+// Handles both quoted (msg="text here") and unquoted (msg=connecting) values.
+func extractLogfmtMsg(line string) string {
+	const key = "msg="
+
+	_, rest, found := strings.Cut(line, key)
+	if !found {
+		return ""
+	}
+	if len(rest) == 0 {
+		return ""
+	}
+
+	if rest[0] == '"' {
+		end := strings.Index(rest[1:], "\"")
+		if end < 0 {
+			return rest[1:]
+		}
+		return rest[1 : end+1]
+	}
+
+	value, _, _ := strings.Cut(rest, " ")
+	return value
 }

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -8,33 +8,34 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 )
 
 var startupAltScreenEnable = []byte("\x1b[?1049h")
 
 const (
-	activateMinVisible = 1      // visible (non-escape) characters after alt-screen
+	activateMinVisible = 1       // visible (non-escape) characters after alt-screen
 	maxBufferSize      = 1 << 20 // defensive cap on buffered data (1 MiB)
 )
 
 var _ io.WriteCloser = (*startupWriter)(nil)
 
 type startupWriter struct {
-	w            io.Writer
-	status       io.Writer
-	logReader    io.Reader
-	logCancel    func()
-	logDone      chan struct{}
-	buf          []byte
-	overlap      []byte
-	ready        bool
+	w              io.Writer
+	status         io.Writer
+	logReader      io.Reader
+	logCancel      func()
+	logDone        chan struct{}
+	buf            []byte
+	overlap        []byte
+	ready          bool
 	altSeen        bool
 	postAltVisible int
 	inEscape       bool
 	escType        byte
 	timer          *time.Timer
-	mu           sync.Mutex
-	timeout      time.Duration
+	mu             sync.Mutex
+	timeout        time.Duration
 }
 
 func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration, logReader io.Reader, logCancel func()) *startupWriter {
@@ -68,6 +69,9 @@ func (s *startupWriter) Write(p []byte) (int, error) {
 
 	s.buf = append(s.buf, p...)
 
+	// Buffer cap exceeded — activate() flushes s.buf (which already
+	// includes the current p via the append above) to s.w and marks
+	// s.ready=true so subsequent Writes bypass buffering.
 	if len(s.buf) > maxBufferSize {
 		s.activate()
 		return len(p), nil
@@ -196,23 +200,21 @@ func (s *startupWriter) readLogs() {
 			continue
 		}
 
-		if len(msg) > 80 {
-			msg = msg[:80]
+		if utf8.RuneCountInString(msg) > 80 {
+			runes := []rune(msg)
+			msg = string(runes[:80])
 		}
 
 		s.mu.Lock()
-		ready := s.ready
-		s.mu.Unlock()
-		if ready {
+		if s.ready {
+			s.mu.Unlock()
 			break
 		}
-
-		if time.Since(lastUpdate) < 100*time.Millisecond {
-			continue
+		if time.Since(lastUpdate) >= 100*time.Millisecond {
+			_, _ = fmt.Fprintf(s.status, "\x1b[2K\r%s", msg)
+			lastUpdate = time.Now()
 		}
-
-		_, _ = fmt.Fprintf(s.status, "\x1b[2K\r%s", msg)
-		lastUpdate = time.Now()
+		s.mu.Unlock()
 	}
 }
 

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"time"
+)
+
+var startupAltScreenEnable = []byte("\x1b[?1049h")
+
+var (
+	_ io.WriteCloser = (*startupWriter)(nil)
+	_                = newStartupWriter
+)
+
+type startupWriter struct {
+	w       io.Writer
+	status  io.Writer
+	buf     []byte
+	overlap []byte
+	ready   bool
+	altSeen bool
+	timer   *time.Timer
+	mu      sync.Mutex
+	timeout time.Duration
+}
+
+func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration) *startupWriter {
+	sw := &startupWriter{w: w, status: status, timeout: timeout}
+	if status == nil {
+		sw.ready = true
+		return sw
+	}
+
+	_, _ = status.Write([]byte("Starting OpenCode...\r\n"))
+	sw.timer = time.AfterFunc(timeout, func() {
+		sw.mu.Lock()
+		defer sw.mu.Unlock()
+		sw.activate()
+	})
+
+	return sw
+}
+
+func (s *startupWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.ready {
+		return s.w.Write(p)
+	}
+
+	s.buf = append(s.buf, p...)
+
+	combined := append(append([]byte{}, s.overlap...), p...)
+	if !s.altSeen && bytes.Contains(combined, startupAltScreenEnable) {
+		s.altSeen = true
+	}
+
+	if s.altSeen && len(p) > 0 {
+		s.activate()
+	}
+
+	if len(p) >= len(startupAltScreenEnable) {
+		s.overlap = append(s.overlap[:0], p[len(p)-len(startupAltScreenEnable):]...)
+	} else {
+		s.overlap = append(s.overlap, p...)
+		if len(s.overlap) > len(startupAltScreenEnable) {
+			s.overlap = s.overlap[len(s.overlap)-len(startupAltScreenEnable):]
+		}
+	}
+
+	return len(p), nil
+}
+
+func (s *startupWriter) activate() {
+	if s.ready {
+		return
+	}
+
+	s.ready = true
+	if s.timer != nil {
+		s.timer.Stop()
+	}
+
+	if s.status != nil {
+		_, _ = s.status.Write([]byte("\x1b[2K\r"))
+	}
+
+	if len(s.buf) > 0 {
+		_, _ = s.w.Write(s.buf)
+		s.buf = nil
+	}
+}
+
+func (s *startupWriter) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.activate()
+	return nil
+}

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -18,7 +18,7 @@ const (
 	maxBufferSize      = 1 << 20 // defensive cap on buffered data (1 MiB)
 )
 
-var _ io.WriteCloser = (*startupWriter)(nil)
+var _ io.Writer = (*startupWriter)(nil)
 
 type startupWriter struct {
 	w              io.Writer
@@ -180,12 +180,11 @@ func (s *startupWriter) countVisibleIn(p []byte) int {
 	return n
 }
 
-func (s *startupWriter) Close() error {
+func (s *startupWriter) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.activate()
-	return nil
 }
 
 func (s *startupWriter) readLogs() {
@@ -202,7 +201,7 @@ func (s *startupWriter) readLogs() {
 
 		if utf8.RuneCountInString(msg) > 80 {
 			runes := []rune(msg)
-			msg = string(runes[:80])
+			msg = string(runes[:79]) + "…"
 		}
 
 		s.mu.Lock()
@@ -221,6 +220,7 @@ func (s *startupWriter) readLogs() {
 // extractLogfmtMsg extracts the value of the msg= field from a logfmt-formatted line.
 // Returns empty string if no msg= field is found or the value is empty.
 // Handles both quoted (msg="text here") and unquoted (msg=connecting) values.
+// Note: backslash-escaped quotes inside quoted values are not handled.
 func extractLogfmtMsg(line string) string {
 	const key = "msg="
 

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -13,8 +13,8 @@ import (
 var startupAltScreenEnable = []byte("\x1b[?1049h")
 
 const (
-	activateMinBytes = 512     // post-alt-screen bytes before activation
-	maxBufferSize    = 1 << 20 // defensive cap on buffered data (1 MiB)
+	activateMinVisible = 1      // visible (non-escape) characters after alt-screen
+	maxBufferSize      = 1 << 20 // defensive cap on buffered data (1 MiB)
 )
 
 var _ io.WriteCloser = (*startupWriter)(nil)
@@ -28,9 +28,11 @@ type startupWriter struct {
 	buf          []byte
 	overlap      []byte
 	ready        bool
-	altSeen      bool
-	postAltBytes int
-	timer        *time.Timer
+	altSeen        bool
+	postAltVisible int
+	inEscape       bool
+	escType        byte
+	timer          *time.Timer
 	mu           sync.Mutex
 	timeout      time.Duration
 }
@@ -71,16 +73,24 @@ func (s *startupWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 
-	combined := append(append([]byte{}, s.overlap...), p...)
-	if !s.altSeen && bytes.Contains(combined, startupAltScreenEnable) {
-		s.altSeen = true
+	if !s.altSeen {
+		combined := append(append([]byte{}, s.overlap...), p...)
+		if idx := bytes.Index(combined, startupAltScreenEnable); idx >= 0 {
+			s.altSeen = true
+			postAltStart := idx + len(startupAltScreenEnable) - len(s.overlap)
+			if postAltStart < 0 {
+				postAltStart = 0
+			}
+			if postAltStart < len(p) {
+				s.postAltVisible += s.countVisibleIn(p[postAltStart:])
+			}
+		}
+	} else {
+		s.postAltVisible += s.countVisibleIn(p)
 	}
 
-	if s.altSeen {
-		s.postAltBytes += len(p)
-		if s.postAltBytes >= activateMinBytes {
-			s.activate()
-		}
+	if s.altSeen && s.postAltVisible >= activateMinVisible {
+		s.activate()
 	}
 
 	if len(p) >= len(startupAltScreenEnable) {
@@ -133,6 +143,37 @@ func (s *startupWriter) activate() {
 		_, _ = s.w.Write(s.buf)
 		s.buf = nil
 	}
+}
+
+func (s *startupWriter) countVisibleIn(p []byte) int {
+	n := 0
+	for _, b := range p {
+		switch {
+		case s.inEscape && s.escType == 0:
+			if b == '[' || b == ']' {
+				s.escType = b
+			} else {
+				s.inEscape = false
+			}
+		case s.inEscape && s.escType == '[':
+			if b >= 0x40 && b <= 0x7E {
+				s.inEscape = false
+			}
+		case s.inEscape && s.escType == ']':
+			switch b {
+			case 0x07:
+				s.inEscape = false
+			case 0x1b:
+				s.escType = 0
+			}
+		case b == 0x1b:
+			s.inEscape = true
+			s.escType = 0
+		case b >= 0x20 && b <= 0x7E:
+			n++
+		}
+	}
+	return n
 }
 
 func (s *startupWriter) Close() error {

--- a/internal/cmd/startupwriter.go
+++ b/internal/cmd/startupwriter.go
@@ -12,24 +12,27 @@ import (
 
 var startupAltScreenEnable = []byte("\x1b[?1049h")
 
-var (
-	_ io.WriteCloser = (*startupWriter)(nil)
-	_                = newStartupWriter
+const (
+	activateMinBytes = 512     // post-alt-screen bytes before activation
+	maxBufferSize    = 1 << 20 // defensive cap on buffered data (1 MiB)
 )
 
+var _ io.WriteCloser = (*startupWriter)(nil)
+
 type startupWriter struct {
-	w         io.Writer
-	status    io.Writer
-	logReader io.Reader
-	logCancel func()
-	logDone   chan struct{}
-	buf       []byte
-	overlap   []byte
-	ready     bool
-	altSeen   bool
-	timer     *time.Timer
-	mu        sync.Mutex
-	timeout   time.Duration
+	w            io.Writer
+	status       io.Writer
+	logReader    io.Reader
+	logCancel    func()
+	logDone      chan struct{}
+	buf          []byte
+	overlap      []byte
+	ready        bool
+	altSeen      bool
+	postAltBytes int
+	timer        *time.Timer
+	mu           sync.Mutex
+	timeout      time.Duration
 }
 
 func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration, logReader io.Reader, logCancel func()) *startupWriter {
@@ -39,7 +42,7 @@ func newStartupWriter(w io.Writer, status io.Writer, timeout time.Duration, logR
 		return sw
 	}
 
-	_, _ = status.Write([]byte("Starting OpenCode...\r\n"))
+	_, _ = status.Write([]byte("Starting OpenCode..."))
 	sw.timer = time.AfterFunc(timeout, func() {
 		sw.mu.Lock()
 		defer sw.mu.Unlock()
@@ -63,13 +66,21 @@ func (s *startupWriter) Write(p []byte) (int, error) {
 
 	s.buf = append(s.buf, p...)
 
+	if len(s.buf) > maxBufferSize {
+		s.activate()
+		return len(p), nil
+	}
+
 	combined := append(append([]byte{}, s.overlap...), p...)
 	if !s.altSeen && bytes.Contains(combined, startupAltScreenEnable) {
 		s.altSeen = true
 	}
 
-	if s.altSeen && len(p) > 0 {
-		s.activate()
+	if s.altSeen {
+		s.postAltBytes += len(p)
+		if s.postAltBytes >= activateMinBytes {
+			s.activate()
+		}
 	}
 
 	if len(p) >= len(startupAltScreenEnable) {

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -119,8 +119,7 @@ func TestStartupWriter_CloseFlushesBuffer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String())
 
-	err = sw.Close()
-	require.NoError(t, err)
+	sw.Close()
 	assert.Equal(t, "pending data", buf.String())
 }
 
@@ -154,8 +153,7 @@ func TestStartupWriter_LoadingMessageErased(t *testing.T) {
 	assert.Equal(t, "Starting OpenCode...", status.String())
 
 	// Trigger activate via Close.
-	err := sw.Close()
-	require.NoError(t, err)
+	sw.Close()
 
 	// Status should now also have the erase sequence.
 	assert.Equal(t, "Starting OpenCode...\x1b[2K\r", status.String())
@@ -307,8 +305,8 @@ func TestStartupWriter_LongMsgTruncated(t *testing.T) {
 	statusStr := status.String()
 	afterInitial := strings.TrimPrefix(statusStr, "Starting OpenCode...")
 	afterErase := strings.TrimPrefix(afterInitial, "\x1b[2K\r")
-	assert.LessOrEqual(t, len(afterErase), 80)
-	assert.Equal(t, strings.Repeat("x", 80), afterErase)
+	assert.LessOrEqual(t, len([]rune(afterErase)), 80)
+	assert.Equal(t, strings.Repeat("x", 79)+"…", afterErase)
 }
 
 func TestStartupWriter_NilLogReaderNoPanic(t *testing.T) {
@@ -320,8 +318,7 @@ func TestStartupWriter_NilLogReaderNoPanic(t *testing.T) {
 
 	assert.Equal(t, "Starting OpenCode...", status.String())
 
-	err := sw.Close()
-	require.NoError(t, err)
+	sw.Close()
 
 	assert.Contains(t, status.String(), "\x1b[2K\r")
 }

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -35,13 +35,13 @@ func TestStartupWriter_BuffersUntilAltScreen(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String(), "data should be buffered, not written to underlying writer")
 
-	// Alt-screen alone should not flush — need substantial content first.
+	// Alt-screen alone should not flush — need visible content.
 	_, err = sw.Write([]byte("\x1b[?1049h"))
 	require.NoError(t, err)
 	assert.Empty(t, buf.String(), "alt-screen alone should not flush")
 
-	// Substantial content triggers activation.
-	content := strings.Repeat("x", activateMinBytes)
+	// Visible content triggers activation.
+	content := strings.Repeat("x", activateMinVisible)
 	_, err = sw.Write([]byte(content))
 	require.NoError(t, err)
 	assert.Equal(t, "buffered data\x1b[?1049h"+content, buf.String())
@@ -64,11 +64,30 @@ func TestStartupWriter_CrossBoundaryDetection(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String(), "should still buffer until enough post-alt content")
 
-	// Substantial content triggers activation.
-	content := strings.Repeat("x", activateMinBytes)
+	// Visible content triggers activation.
+	content := strings.Repeat("x", activateMinVisible)
 	_, err = sw.Write([]byte(content))
 	require.NoError(t, err)
 	assert.Equal(t, "somedata\x1b[?1049h\x1b[H\x1b[2J"+content, buf.String())
+}
+
+func TestStartupWriter_EscapeOnlyDoesNotActivate(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
+
+	_, err := sw.Write([]byte("\x1b[?1049h"))
+	require.NoError(t, err)
+
+	_, err = sw.Write([]byte("\x1b[H\x1b[2J\x1b[?25l\x1b[1;1H\x1b[2K\x1b[2;1H\x1b[2K"))
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "escape-only content should not activate")
+
+	_, err = sw.Write([]byte("A"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, buf.String(), "first visible character should activate")
 }
 
 func TestStartupWriter_TimeoutFlushes(t *testing.T) {
@@ -113,7 +132,7 @@ func TestStartupWriter_ReadyPassthrough(t *testing.T) {
 	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	// Trigger activation with alt-screen + substantial content.
-	content := "\x1b[?1049h" + strings.Repeat("x", activateMinBytes)
+	content := "\x1b[?1049h" + strings.Repeat("x", activateMinVisible)
 	_, err := sw.Write([]byte(content))
 	require.NoError(t, err)
 
@@ -341,7 +360,7 @@ func TestStartupWriter_GoroutineExitsOnActivate(t *testing.T) {
 
 	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, cancelFn)
 
-	_, err := sw.Write([]byte("\x1b[?1049h" + strings.Repeat("x", activateMinBytes)))
+	_, err := sw.Write([]byte("\x1b[?1049h" + strings.Repeat("x", activateMinVisible)))
 	require.NoError(t, err)
 
 	select {
@@ -380,7 +399,7 @@ func TestStartupWriter_NoStatusWritesAfterActivate(t *testing.T) {
 
 	time.Sleep(150 * time.Millisecond)
 
-	_, err := sw.Write([]byte("\x1b[?1049h" + strings.Repeat("x", activateMinBytes)))
+	_, err := sw.Write([]byte("\x1b[?1049h" + strings.Repeat("x", activateMinVisible)))
 	require.NoError(t, err)
 
 	select {

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartupWriter_PassthroughWhenNilStatus(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	sw := newStartupWriter(&buf, nil, time.Second)
+
+	n, err := sw.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", buf.String())
+}
+
+func TestStartupWriter_BuffersUntilAltScreen(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second)
+
+	// Write data without alt-screen escape — should be buffered.
+	_, err := sw.Write([]byte("buffered data"))
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "data should be buffered, not written to underlying writer")
+
+	// Write alt-screen enable + content — should flush everything.
+	_, err = sw.Write([]byte("\x1b[?1049h\x1b[H"))
+	require.NoError(t, err)
+	assert.Equal(t, "buffered data\x1b[?1049h\x1b[H", buf.String())
+}
+
+func TestStartupWriter_CrossBoundaryDetection(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second)
+
+	// First write ends mid-sequence: \x1b[?10 (5 of 8 bytes).
+	_, err := sw.Write([]byte("somedata\x1b[?10"))
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "should still be buffering")
+
+	// Second write completes the sequence: 49h + more content.
+	_, err = sw.Write([]byte("49h\x1b[H\x1b[2J"))
+	require.NoError(t, err)
+	assert.Equal(t, "somedata\x1b[?1049h\x1b[H\x1b[2J", buf.String())
+}
+
+func TestStartupWriter_TimeoutFlushes(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 50*time.Millisecond)
+
+	_, err := sw.Write([]byte("waiting for timeout"))
+	require.NoError(t, err)
+	assert.Empty(t, buf.String(), "should be buffered before timeout")
+
+	time.Sleep(150 * time.Millisecond)
+
+	assert.Equal(t, "waiting for timeout", buf.String())
+}
+
+func TestStartupWriter_CloseFlushesBuffer(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second)
+
+	_, err := sw.Write([]byte("pending data"))
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+
+	err = sw.Close()
+	require.NoError(t, err)
+	assert.Equal(t, "pending data", buf.String())
+}
+
+func TestStartupWriter_ReadyPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second)
+
+	// Trigger detection with alt-screen sequence.
+	_, err := sw.Write([]byte("\x1b[?1049h"))
+	require.NoError(t, err)
+
+	// Subsequent writes should pass through directly.
+	buf.Reset()
+	_, err = sw.Write([]byte("direct output"))
+	require.NoError(t, err)
+	assert.Equal(t, "direct output", buf.String())
+}
+
+func TestStartupWriter_LoadingMessageErased(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second)
+
+	// Status should have the loading message from constructor.
+	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+
+	// Trigger activate via Close.
+	err := sw.Close()
+	require.NoError(t, err)
+
+	// Status should now also have the erase sequence.
+	assert.Equal(t, "Starting OpenCode...\r\n\x1b[2K\r", status.String())
+}

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -35,10 +35,16 @@ func TestStartupWriter_BuffersUntilAltScreen(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String(), "data should be buffered, not written to underlying writer")
 
-	// Write alt-screen enable + content — should flush everything.
-	_, err = sw.Write([]byte("\x1b[?1049h\x1b[H"))
+	// Alt-screen alone should not flush — need substantial content first.
+	_, err = sw.Write([]byte("\x1b[?1049h"))
 	require.NoError(t, err)
-	assert.Equal(t, "buffered data\x1b[?1049h\x1b[H", buf.String())
+	assert.Empty(t, buf.String(), "alt-screen alone should not flush")
+
+	// Substantial content triggers activation.
+	content := strings.Repeat("x", activateMinBytes)
+	_, err = sw.Write([]byte(content))
+	require.NoError(t, err)
+	assert.Equal(t, "buffered data\x1b[?1049h"+content, buf.String())
 }
 
 func TestStartupWriter_CrossBoundaryDetection(t *testing.T) {
@@ -53,10 +59,16 @@ func TestStartupWriter_CrossBoundaryDetection(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, buf.String(), "should still be buffering")
 
-	// Second write completes the sequence: 49h + more content.
+	// Second write completes the sequence but doesn't activate yet.
 	_, err = sw.Write([]byte("49h\x1b[H\x1b[2J"))
 	require.NoError(t, err)
-	assert.Equal(t, "somedata\x1b[?1049h\x1b[H\x1b[2J", buf.String())
+	assert.Empty(t, buf.String(), "should still buffer until enough post-alt content")
+
+	// Substantial content triggers activation.
+	content := strings.Repeat("x", activateMinBytes)
+	_, err = sw.Write([]byte(content))
+	require.NoError(t, err)
+	assert.Equal(t, "somedata\x1b[?1049h\x1b[H\x1b[2J"+content, buf.String())
 }
 
 func TestStartupWriter_TimeoutFlushes(t *testing.T) {
@@ -72,7 +84,9 @@ func TestStartupWriter_TimeoutFlushes(t *testing.T) {
 
 	time.Sleep(150 * time.Millisecond)
 
-	assert.Equal(t, "waiting for timeout", buf.String())
+	require.Eventually(t, func() bool {
+		return buf.String() == "waiting for timeout"
+	}, 2*time.Second, 10*time.Millisecond)
 }
 
 func TestStartupWriter_CloseFlushesBuffer(t *testing.T) {
@@ -98,8 +112,9 @@ func TestStartupWriter_ReadyPassthrough(t *testing.T) {
 	var status bytes.Buffer
 	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
-	// Trigger detection with alt-screen sequence.
-	_, err := sw.Write([]byte("\x1b[?1049h"))
+	// Trigger activation with alt-screen + substantial content.
+	content := "\x1b[?1049h" + strings.Repeat("x", activateMinBytes)
+	_, err := sw.Write([]byte(content))
 	require.NoError(t, err)
 
 	// Subsequent writes should pass through directly.
@@ -117,14 +132,14 @@ func TestStartupWriter_LoadingMessageErased(t *testing.T) {
 	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	// Status should have the loading message from constructor.
-	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+	assert.Equal(t, "Starting OpenCode...", status.String())
 
 	// Trigger activate via Close.
 	err := sw.Close()
 	require.NoError(t, err)
 
 	// Status should now also have the erase sequence.
-	assert.Equal(t, "Starting OpenCode...\r\n\x1b[2K\r", status.String())
+	assert.Equal(t, "Starting OpenCode...\x1b[2K\r", status.String())
 }
 
 func TestStartupWriter_LogMessageAppearsInStatus(t *testing.T) {
@@ -221,7 +236,7 @@ func TestStartupWriter_NonLogfmtLineSkipped(t *testing.T) {
 		t.Fatal("goroutine did not exit")
 	}
 
-	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+	assert.Equal(t, "Starting OpenCode...", status.String())
 }
 
 func TestStartupWriter_EmptyMsgSkipped(t *testing.T) {
@@ -245,7 +260,7 @@ func TestStartupWriter_EmptyMsgSkipped(t *testing.T) {
 		t.Fatal("goroutine did not exit")
 	}
 
-	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+	assert.Equal(t, "Starting OpenCode...", status.String())
 }
 
 func TestStartupWriter_LongMsgTruncated(t *testing.T) {
@@ -271,7 +286,7 @@ func TestStartupWriter_LongMsgTruncated(t *testing.T) {
 	}
 
 	statusStr := status.String()
-	afterInitial := strings.TrimPrefix(statusStr, "Starting OpenCode...\r\n")
+	afterInitial := strings.TrimPrefix(statusStr, "Starting OpenCode...")
 	afterErase := strings.TrimPrefix(afterInitial, "\x1b[2K\r")
 	assert.LessOrEqual(t, len(afterErase), 80)
 	assert.Equal(t, strings.Repeat("x", 80), afterErase)
@@ -284,7 +299,7 @@ func TestStartupWriter_NilLogReaderNoPanic(t *testing.T) {
 	var status bytes.Buffer
 	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
-	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+	assert.Equal(t, "Starting OpenCode...", status.String())
 
 	err := sw.Close()
 	require.NoError(t, err)
@@ -326,7 +341,7 @@ func TestStartupWriter_GoroutineExitsOnActivate(t *testing.T) {
 
 	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, cancelFn)
 
-	_, err := sw.Write([]byte("\x1b[?1049h"))
+	_, err := sw.Write([]byte("\x1b[?1049h" + strings.Repeat("x", activateMinBytes)))
 	require.NoError(t, err)
 
 	select {
@@ -365,7 +380,7 @@ func TestStartupWriter_NoStatusWritesAfterActivate(t *testing.T) {
 
 	time.Sleep(150 * time.Millisecond)
 
-	_, err := sw.Write([]byte("\x1b[?1049h"))
+	_, err := sw.Write([]byte("\x1b[?1049h" + strings.Repeat("x", activateMinBytes)))
 	require.NoError(t, err)
 
 	select {

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -90,7 +90,7 @@ func TestStartupWriter_EscapeOnlyDoesNotActivate(t *testing.T) {
 	assert.NotEmpty(t, buf.String(), "first visible character should activate")
 }
 
-func TestStartupWriter_TimeoutFlushes(t *testing.T) {
+func TestStartupWriter_SlowStartWarning(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
@@ -103,9 +103,15 @@ func TestStartupWriter_TimeoutFlushes(t *testing.T) {
 
 	time.Sleep(150 * time.Millisecond)
 
-	require.Eventually(t, func() bool {
-		return buf.String() == "waiting for timeout"
-	}, 2*time.Second, 10*time.Millisecond)
+	// Buffer should NOT be flushed — still buffering.
+	assert.Empty(t, buf.String(), "timeout should not flush the buffer")
+
+	// Status should contain the slow-start warning.
+	assert.Contains(t, status.String(), "unusually long")
+
+	// Close flushes normally.
+	sw.Close()
+	assert.Equal(t, "waiting for timeout", buf.String())
 }
 
 func TestStartupWriter_CloseFlushesBuffer(t *testing.T) {

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -216,7 +216,7 @@ func TestStartupWriter_UnquotedMsgExtracted(t *testing.T) {
 	var buf bytes.Buffer
 	var status bytes.Buffer
 	pr, pw := io.Pipe()
-		t.Cleanup(func() { _ = pw.Close() })
+	t.Cleanup(func() { _ = pw.Close() })
 
 	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
 
@@ -240,7 +240,7 @@ func TestStartupWriter_NonLogfmtLineSkipped(t *testing.T) {
 	var buf bytes.Buffer
 	var status bytes.Buffer
 	pr, pw := io.Pipe()
-		t.Cleanup(func() { _ = pw.Close() })
+	t.Cleanup(func() { _ = pw.Close() })
 
 	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
 
@@ -264,7 +264,7 @@ func TestStartupWriter_EmptyMsgSkipped(t *testing.T) {
 	var buf bytes.Buffer
 	var status bytes.Buffer
 	pr, pw := io.Pipe()
-		t.Cleanup(func() { _ = pw.Close() })
+	t.Cleanup(func() { _ = pw.Close() })
 
 	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
 
@@ -350,7 +350,7 @@ func TestStartupWriter_GoroutineExitsOnActivate(t *testing.T) {
 	var buf bytes.Buffer
 	var status bytes.Buffer
 	pr, pw := io.Pipe()
-		t.Cleanup(func() { _ = pw.Close() })
+	t.Cleanup(func() { _ = pw.Close() })
 
 	cancelled := make(chan struct{})
 	cancelFn := func() {

--- a/internal/cmd/startupwriter_test.go
+++ b/internal/cmd/startupwriter_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,7 +15,7 @@ func TestStartupWriter_PassthroughWhenNilStatus(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	sw := newStartupWriter(&buf, nil, time.Second)
+	sw := newStartupWriter(&buf, nil, time.Second, nil, nil)
 
 	n, err := sw.Write([]byte("hello"))
 	require.NoError(t, err)
@@ -26,7 +28,7 @@ func TestStartupWriter_BuffersUntilAltScreen(t *testing.T) {
 
 	var buf bytes.Buffer
 	var status bytes.Buffer
-	sw := newStartupWriter(&buf, &status, 5*time.Second)
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	// Write data without alt-screen escape — should be buffered.
 	_, err := sw.Write([]byte("buffered data"))
@@ -44,7 +46,7 @@ func TestStartupWriter_CrossBoundaryDetection(t *testing.T) {
 
 	var buf bytes.Buffer
 	var status bytes.Buffer
-	sw := newStartupWriter(&buf, &status, 5*time.Second)
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	// First write ends mid-sequence: \x1b[?10 (5 of 8 bytes).
 	_, err := sw.Write([]byte("somedata\x1b[?10"))
@@ -62,7 +64,7 @@ func TestStartupWriter_TimeoutFlushes(t *testing.T) {
 
 	var buf bytes.Buffer
 	var status bytes.Buffer
-	sw := newStartupWriter(&buf, &status, 50*time.Millisecond)
+	sw := newStartupWriter(&buf, &status, 50*time.Millisecond, nil, nil)
 
 	_, err := sw.Write([]byte("waiting for timeout"))
 	require.NoError(t, err)
@@ -78,7 +80,7 @@ func TestStartupWriter_CloseFlushesBuffer(t *testing.T) {
 
 	var buf bytes.Buffer
 	var status bytes.Buffer
-	sw := newStartupWriter(&buf, &status, 5*time.Second)
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	_, err := sw.Write([]byte("pending data"))
 	require.NoError(t, err)
@@ -94,7 +96,7 @@ func TestStartupWriter_ReadyPassthrough(t *testing.T) {
 
 	var buf bytes.Buffer
 	var status bytes.Buffer
-	sw := newStartupWriter(&buf, &status, 5*time.Second)
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	// Trigger detection with alt-screen sequence.
 	_, err := sw.Write([]byte("\x1b[?1049h"))
@@ -112,7 +114,7 @@ func TestStartupWriter_LoadingMessageErased(t *testing.T) {
 
 	var buf bytes.Buffer
 	var status bytes.Buffer
-	sw := newStartupWriter(&buf, &status, 5*time.Second)
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
 
 	// Status should have the loading message from constructor.
 	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
@@ -123,4 +125,292 @@ func TestStartupWriter_LoadingMessageErased(t *testing.T) {
 
 	// Status should now also have the erase sequence.
 	assert.Equal(t, "Starting OpenCode...\r\n\x1b[2K\r", status.String())
+}
+
+func TestStartupWriter_LogMessageAppearsInStatus(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	go func() {
+		_, _ = pw.Write([]byte("time=2024-01-01T00:00:00Z level=INFO msg=\"Loading config\"\n"))
+		_ = pw.Close()
+	}()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	assert.Contains(t, status.String(), "Loading config")
+	assert.NotContains(t, status.String(), "time=")
+}
+
+func TestStartupWriter_QuotedMsgWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	go func() {
+		_, _ = pw.Write([]byte("level=DEBUG msg=\"LSP server is ready\" component=lsp\n"))
+		_ = pw.Close()
+	}()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	assert.Contains(t, status.String(), "LSP server is ready")
+}
+
+func TestStartupWriter_UnquotedMsgExtracted(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	go func() {
+		_, _ = pw.Write([]byte("time=2024 level=INFO msg=connecting\n"))
+		_ = pw.Close()
+	}()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	assert.Contains(t, status.String(), "connecting")
+}
+
+func TestStartupWriter_NonLogfmtLineSkipped(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	go func() {
+		_, _ = pw.Write([]byte("Setting up iptables rules...\n"))
+		_ = pw.Close()
+	}()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+}
+
+func TestStartupWriter_EmptyMsgSkipped(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	go func() {
+		_, _ = pw.Write([]byte("level=INFO msg=\"\"\n"))
+		_ = pw.Close()
+	}()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+}
+
+func TestStartupWriter_LongMsgTruncated(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	longMsg := strings.Repeat("x", 200)
+	go func() {
+		_, _ = pw.Write([]byte("level=INFO msg=\"" + longMsg + "\"\n"))
+		_ = pw.Close()
+	}()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	statusStr := status.String()
+	afterInitial := strings.TrimPrefix(statusStr, "Starting OpenCode...\r\n")
+	afterErase := strings.TrimPrefix(afterInitial, "\x1b[2K\r")
+	assert.LessOrEqual(t, len(afterErase), 80)
+	assert.Equal(t, strings.Repeat("x", 80), afterErase)
+}
+
+func TestStartupWriter_NilLogReaderNoPanic(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	sw := newStartupWriter(&buf, &status, 5*time.Second, nil, nil)
+
+	assert.Equal(t, "Starting OpenCode...\r\n", status.String())
+
+	err := sw.Close()
+	require.NoError(t, err)
+
+	assert.Contains(t, status.String(), "\x1b[2K\r")
+}
+
+func TestStartupWriter_GoroutineExitsOnReaderClose(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, func() {})
+
+	_ = pw.Close()
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after reader was closed")
+	}
+}
+
+func TestStartupWriter_GoroutineExitsOnActivate(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+		t.Cleanup(func() { _ = pw.Close() })
+
+	cancelled := make(chan struct{})
+	cancelFn := func() {
+		close(cancelled)
+		_ = pw.Close()
+	}
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, cancelFn)
+
+	_, err := sw.Write([]byte("\x1b[?1049h"))
+	require.NoError(t, err)
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after activate")
+	}
+}
+
+func TestStartupWriter_NoStatusWritesAfterActivate(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var status bytes.Buffer
+	pr, pw := io.Pipe()
+
+	cancelled := make(chan struct{})
+	cancelFn := func() {
+		close(cancelled)
+		_ = pw.Close()
+	}
+
+	sw := newStartupWriter(&buf, &status, 5*time.Second, pr, cancelFn)
+
+	go func() {
+		_, _ = pw.Write([]byte("level=INFO msg=\"first line\"\n"))
+		for i := 0; i < 10; i++ {
+			select {
+			case <-cancelled:
+				return
+			case <-time.After(10 * time.Millisecond):
+			}
+			_, _ = pw.Write([]byte("level=INFO msg=\"more data\"\n"))
+		}
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+
+	_, err := sw.Write([]byte("\x1b[?1049h"))
+	require.NoError(t, err)
+
+	select {
+	case <-sw.logDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit")
+	}
+
+	statusLenAfterActivate := status.Len()
+
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, statusLenAfterActivate, status.Len(), "status should not grow after activate")
+}
+
+func TestExtractLogfmtMsg_UnquotedValue(t *testing.T) {
+	t.Parallel()
+
+	result := extractLogfmtMsg("level=INFO msg=connecting")
+	assert.Equal(t, "connecting", result)
+}
+
+func TestExtractLogfmtMsg_QuotedWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	result := extractLogfmtMsg(`level=INFO msg="LSP is ready" component=x`)
+	assert.Equal(t, "LSP is ready", result)
+}
+
+func TestExtractLogfmtMsg_NoMsgField(t *testing.T) {
+	t.Parallel()
+
+	result := extractLogfmtMsg("Setting up iptables")
+	assert.Equal(t, "", result)
+}
+
+func TestExtractLogfmtMsg_EmptyMsg(t *testing.T) {
+	t.Parallel()
+
+	result := extractLogfmtMsg(`msg=""`)
+	assert.Equal(t, "", result)
+}
+
+func TestExtractLogfmtMsg_MsgAtEnd(t *testing.T) {
+	t.Parallel()
+
+	result := extractLogfmtMsg("level=INFO msg=done")
+	assert.Equal(t, "done", result)
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -242,6 +242,19 @@ func (c *Client) Logs(ctx context.Context, follow bool, w io.Writer) error {
 	return nil
 }
 
+func (c *Client) StreamRecentLogs(ctx context.Context, w io.Writer) error {
+	if err := c.initComposeSvc(); err != nil {
+		return fmt.Errorf("stream logs: %w", err)
+	}
+
+	consumer := &writerLogConsumer{w: w}
+	if err := c.svc.Logs(ctx, "jailoc-"+c.workspace, consumer, api.LogOptions{Follow: true, Tail: "5"}); err != nil {
+		return fmt.Errorf("compose logs for workspace %q: %w", c.workspace, err)
+	}
+
+	return nil
+}
+
 func (c *Client) TailLogs(ctx context.Context, n int, w io.Writer) error {
 	if err := c.initComposeSvc(); err != nil {
 		return err

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -242,6 +242,8 @@ func (c *Client) Logs(ctx context.Context, follow bool, w io.Writer) error {
 	return nil
 }
 
+// StreamRecentLogs streams container logs to w, starting from the last 5 log
+// entries and following new output until the context is cancelled.
 func (c *Client) StreamRecentLogs(ctx context.Context, w io.Writer) error {
 	if err := c.initComposeSvc(); err != nil {
 		return fmt.Errorf("stream logs: %w", err)


### PR DESCRIPTION
## Summary

- Add `startupWriter` (`internal/cmd/startupwriter.go`) that buffers OpenCode output and shows "Starting OpenCode..." until the TUI renders (alt-screen detection) or 5s timeout fires
- Integrate into both `attachOnHost` (PTY) and `attachExec` (Docker) modes with terminal detection — piped output skips the indicator
- 7 unit tests with testify covering passthrough, buffering, cross-boundary escape detection, timeout, close flush, and message erasure

Closes #115