### PR TITLE
fix(cmd): enable Windows cross-compilation with PTY fallback

### DIFF
--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -154,6 +154,9 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	// us intercept stdout through the exitRewriter.
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
+		if errors.Is(err, pty.ErrUnsupported) {
+			return errPTYUnsupported
+		}
 		return fmt.Errorf("start command with pty: %w", err)
 	}
 	defer func() {
@@ -266,6 +269,7 @@ const (
 )
 
 var errUnhealthy = errors.New("opencode process unhealthy inside container")
+var errPTYUnsupported = errors.New("PTY not supported on this platform")
 
 func startAttachWatch(parent context.Context, client *docker.Client, workspaceName string) (context.Context, func(), error) {
 	containerID, err := client.CurrentContainerID(parent)

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -164,28 +164,30 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	closeWaitDone := sync.OnceFunc(func() { close(waitDone) })
 	defer closeWaitDone()
 
-	// Forward terminal resizes to the PTY.
-	sigCh := make(chan os.Signal, 1)
-	sigDone := make(chan struct{})
-	signal.Notify(sigCh, syscall.SIGWINCH)
-	go func() {
-		defer close(sigDone)
-		for {
-			select {
-			case <-sigCh:
-				_ = pty.InheritSize(os.Stdin, ptmx)
-			case <-ctx.Done():
-				return
-			case <-waitDone:
-				return
+	if sigWinch != nil {
+		// Forward terminal resizes to the PTY.
+		sigCh := make(chan os.Signal, 1)
+		sigDone := make(chan struct{})
+		signal.Notify(sigCh, sigWinch)
+		go func() {
+			defer close(sigDone)
+			for {
+				select {
+				case <-sigCh:
+					_ = pty.InheritSize(os.Stdin, ptmx)
+				case <-ctx.Done():
+					return
+				case <-waitDone:
+					return
+				}
 			}
-		}
-	}()
-	defer func() {
-		signal.Stop(sigCh)
-		closeWaitDone()
-		<-sigDone
-	}()
+		}()
+		defer func() {
+			signal.Stop(sigCh)
+			closeWaitDone()
+			<-sigDone
+		}()
+	}
 	_ = pty.InheritSize(os.Stdin, ptmx)
 
 	// Raw mode so keystrokes pass through verbatim (Ctrl-C, arrows, etc.).
@@ -232,7 +234,7 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	// PTY reads commonly return EIO when the slave side closes on normal
 	// process exit — treat it as expected EOF. Surface other copy errors
 	// only when the process itself exited cleanly.
-	if copyErr != nil && err == nil && !errors.Is(copyErr, syscall.EIO) {
+	if copyErr != nil && err == nil && !errors.Is(copyErr, errEIO) {
 		err = fmt.Errorf("copy pty output: %w", copyErr)
 	}
 	if ferr := rw.Flush(); ferr != nil && err == nil {

--- a/internal/cmd/attach_test.go
+++ b/internal/cmd/attach_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,6 +148,42 @@ func TestAttachExecArgs(t *testing.T) {
 			got := attachExecArgs(tt.serverURL, tt.dir, tt.session, tt.cont)
 			if !slicesEqual(got, tt.want) {
 				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrPTYUnsupported(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		isMatch bool
+	}{
+		{
+			name:    "matches sentinel directly",
+			err:     errPTYUnsupported,
+			isMatch: true,
+		},
+		{
+			name:    "matches wrapped sentinel",
+			err:     fmt.Errorf("wrap: %w", errPTYUnsupported),
+			isMatch: true,
+		},
+		{
+			name:    "does not match different error",
+			err:     errors.New("other error"),
+			isMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := errors.Is(tt.err, errPTYUnsupported); got != tt.isMatch {
+				t.Errorf("errors.Is(%v, errPTYUnsupported) = %v, want %v", tt.err, got, tt.isMatch)
 			}
 		})
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -168,6 +168,13 @@ var rootCmd = &cobra.Command{
 		default:
 			_, _ = color.New(color.FgCyan).Printf("Attaching to workspace %s (remote mode)...\n", ws.Name)
 			attachErr = attachOnHost(attachCtx, ws, targetPath, cfg.PasswordMode, sessionFlag, continueFlag)
+			if errors.Is(attachErr, errPTYUnsupported) {
+				if remoteFlag {
+					return fmt.Errorf("remote mode requires PTY support, which is not available on this platform; use --exec instead")
+				}
+				_, _ = color.New(color.FgYellow).Println("PTY not supported, falling back to exec mode...")
+				attachErr = attachExec(attachCtx, client, targetPath, sessionFlag, continueFlag)
+			}
 		}
 		if attachErr != nil {
 			return fmt.Errorf("attach to workspace %q: %w", ws.Name, attachErr)

--- a/internal/cmd/sigwinch_unix.go
+++ b/internal/cmd/sigwinch_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"syscall"
+)
+
+var sigWinch os.Signal = syscall.SIGWINCH
+
+var errEIO = syscall.EIO

--- a/internal/cmd/sigwinch_windows.go
+++ b/internal/cmd/sigwinch_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package cmd
+
+import (
+	"errors"
+	"os"
+)
+
+var sigWinch os.Signal // nil — PTY resize not supported on Windows
+
+var errEIO = errors.New("input/output error")


### PR DESCRIPTION
Closes #160

`syscall.SIGWINCH` and `syscall.EIO` are undefined on Windows, breaking `GOOS=windows go build`. This PR gates them behind build tags and adds a PTY→exec fallback for unsupported platforms.

### Changes

- **Build-tag split**: `sigwinch_unix.go` / `sigwinch_windows.go` define `sigWinch` and `errEIO` per platform. Resize handler guarded with `if sigWinch != nil`.
- **PTY fallback**: `attachOnHost` returns `errPTYUnsupported` when `pty.ErrUnsupported` is detected. `root.go` catches it — explicit `--remote` errors out, auto-selected mode falls back to exec with a yellow notice.
- **Test**: `TestErrPTYUnsupported` — sentinel error matching (direct, wrapped, negative).

### Verification

Cross-compilation matrix (windows/amd64, linux/amd64, linux/arm64, darwin/amd64, darwin/arm64), `go test ./...`, `go vet ./...`, `golangci-lint run` — all pass.