### PR TITLE
fix(docker): clarify overlay build status message

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -522,7 +522,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 	overlayBuildArgs := proxyBuildArgs()
 	overlayBuildArgs["BASE"] = &baseArg
 
-	_, _ = color.New(color.FgCyan).Printf("Building workspace overlay image...\n")
+	_, _ = color.New(color.FgCyan).Printf("Building workspace overlay image (sending build context to Docker daemon)...\n")
 	resp, err := engineCli.ImageBuild(ctx, buildCtx, build.ImageBuildOptions{
 		Tags:       []string{overlayTag},
 		BuildArgs:  overlayBuildArgs,


### PR DESCRIPTION
## Summary

- Clarify the overlay build message to indicate the build context is being sent to Docker daemon, avoiding the appearance of a hang before build output starts streaming.