### PR TITLE
fix(config): use filepath.IsAbs for cross-platform path validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/compose-spec/compose-go/v2 v2.10.2
 	github.com/creack/pty/v2 v2.0.1
 	github.com/docker/cli v29.4.1+incompatible
 	github.com/docker/compose/v5 v5.1.3
@@ -26,7 +27,6 @@ require (
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/compose-spec/compose-go/v2 v2.10.2 // indirect
 	github.com/containerd/console v1.0.5 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect
 	github.com/containerd/containerd/v2 v2.2.3 // indirect

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -77,7 +77,7 @@ func splitMountSpec(spec string) (host, container, mode string, ok bool) {
 	if strings.HasPrefix(spec, ":") {
 		rest := spec[1:]
 		parts := strings.SplitN(rest, ":", 2)
-		if len(parts) == 0 || parts[0] == "" {
+		if parts[0] == "" {
 			return "", "", "", false
 		}
 		m := "rw"

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -71,10 +71,12 @@ func containerPath(hostPath string) string {
 // splitMountSpec splits a mount spec string (host:container[:mode]) into its
 // parts, handling Windows drive-letter prefixes in the host path where the
 // colon after the drive letter is part of the path, not a field separator.
+// Only drive-absolute paths (e.g. C:\foo, D:/bar) are recognised; a path
+// separator must follow the colon to avoid mis-parsing specs like "a:/container".
 func splitMountSpec(spec string) (host, container, mode string, ok bool) {
 	s := spec
 	hostPrefix := ""
-	if len(s) >= 2 && s[1] == ':' &&
+	if len(s) >= 3 && s[1] == ':' && (s[2] == '\\' || s[2] == '/') &&
 		((s[0] >= 'a' && s[0] <= 'z') || (s[0] >= 'A' && s[0] <= 'Z')) {
 		hostPrefix = s[:2]
 		s = s[2:]

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -57,12 +57,41 @@ func yamlQuote(s string) string {
 // containerPath converts a host filesystem path to a Linux container path.
 // On Unix hosts the path is already valid; on Windows it converts
 // backslashes to forward slashes and turns "C:\foo" into "/C/foo".
+// Only absolute drive paths (e.g. C:\foo, D:/bar) are rewritten;
+// drive-relative paths like "C:foo" are left unchanged.
 func containerPath(hostPath string) string {
 	p := strings.ReplaceAll(hostPath, `\`, "/")
-	if len(p) >= 2 && p[1] == ':' {
+	if len(p) >= 3 && p[1] == ':' && p[2] == '/' &&
+		((p[0] >= 'a' && p[0] <= 'z') || (p[0] >= 'A' && p[0] <= 'Z')) {
 		p = "/" + string(p[0]) + p[2:]
 	}
 	return p
+}
+
+// splitMountSpec splits a mount spec string (host:container[:mode]) into its
+// parts, handling Windows drive-letter prefixes in the host path where the
+// colon after the drive letter is part of the path, not a field separator.
+func splitMountSpec(spec string) (host, container, mode string, ok bool) {
+	s := spec
+	hostPrefix := ""
+	if len(s) >= 2 && s[1] == ':' &&
+		((s[0] >= 'a' && s[0] <= 'z') || (s[0] >= 'A' && s[0] <= 'Z')) {
+		hostPrefix = s[:2]
+		s = s[2:]
+	}
+
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) < 2 {
+		return "", "", "", false
+	}
+
+	host = hostPrefix + parts[0]
+	container = parts[1]
+	mode = "rw"
+	if len(parts) == 3 {
+		mode = parts[2]
+	}
+	return host, container, mode, true
 }
 
 func WriteComposeFile(params ComposeParams, destPath string) error {
@@ -78,46 +107,43 @@ func WriteComposeFile(params ComposeParams, destPath string) error {
 	return nil
 }
 
-func MountsContainTarget(mounts []string, containerPath string) bool {
+func MountsContainTarget(mounts []string, target string) bool {
 	for _, m := range mounts {
-		parts := strings.SplitN(m, ":", 3)
-		if len(parts) >= 2 && parts[1] == containerPath {
+		_, container, _, ok := splitMountSpec(m)
+		if ok && container == target {
 			return true
 		}
 	}
 	return false
 }
 
-func ReadOnlyMountCoversPath(mounts []string, containerPath string) (hostPath string, found bool) {
-	var bestHost, bestTarget, bestOptions string
+func ReadOnlyMountCoversPath(mounts []string, target string) (hostPath string, found bool) {
+	var bestHost, bestTarget, bestMode string
 	bestLen := -1
 
 	for _, m := range mounts {
-		parts := strings.SplitN(m, ":", 3)
-		if len(parts) < 3 {
+		host, container, mode, ok := splitMountSpec(m)
+		if !ok {
 			continue
 		}
-		host := parts[0]
-		target := parts[1]
-		options := parts[2]
 
-		if target != containerPath && !strings.HasPrefix(containerPath, target+"/") {
+		if container != target && !strings.HasPrefix(target, container+"/") {
 			continue
 		}
-		if len(target) > bestLen {
+		if len(container) > bestLen {
 			bestHost = host
-			bestTarget = target
-			bestOptions = options
-			bestLen = len(target)
+			bestTarget = container
+			bestMode = mode
+			bestLen = len(container)
 		}
 	}
 
-	if bestLen < 0 || bestOptions != "ro" {
+	if bestLen < 0 || bestMode != "ro" {
 		return "", false
 	}
-	if bestTarget == containerPath {
+	if bestTarget == target {
 		return bestHost, true
 	}
-	suffix := containerPath[len(bestTarget):]
+	suffix := target[len(bestTarget):]
 	return bestHost + suffix, true
 }

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -56,16 +56,19 @@ func yamlQuote(s string) string {
 }
 
 // containerPath converts a host filesystem path to a Linux container path.
-// It unconditionally normalizes backslashes to forward slashes and on
-// Windows turns absolute drive paths (e.g. C:\foo, D:/bar) into "/C/foo".
-// Drive-relative paths like "C:foo" are left unchanged.
+// Only drive-absolute Windows paths (e.g. C:\foo, D:/bar) are normalized:
+// backslashes become forward slashes and the drive prefix becomes "/C/foo".
+// All other paths (Unix absolute, drive-relative, volume-less rooted) are
+// returned unchanged to avoid silently mapping ambiguous forms into sensitive
+// container directories.
 func containerPath(hostPath string) string {
-	p := strings.ReplaceAll(hostPath, `\`, "/")
-	if len(p) >= 3 && p[1] == ':' && p[2] == '/' &&
-		((p[0] >= 'a' && p[0] <= 'z') || (p[0] >= 'A' && p[0] <= 'Z')) {
-		p = "/" + string(p[0]) + p[2:]
+	if len(hostPath) >= 3 &&
+		((hostPath[0] >= 'a' && hostPath[0] <= 'z') || (hostPath[0] >= 'A' && hostPath[0] <= 'Z')) &&
+		hostPath[1] == ':' && (hostPath[2] == '\\' || hostPath[2] == '/') {
+		p := strings.ReplaceAll(hostPath, `\`, "/")
+		return "/" + string(p[0]) + p[2:]
 	}
-	return p
+	return hostPath
 }
 
 // splitMountSpec splits a mount spec string (host:container[:mode]) into its

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -33,8 +33,9 @@ type ComposeParams struct {
 
 func GenerateCompose(params ComposeParams) ([]byte, error) {
 	tmpl, err := template.New("docker-compose.yml").Funcs(template.FuncMap{
-		"base":      filepath.Base,
-		"yamlQuote": yamlQuote,
+		"base":          filepath.Base,
+		"yamlQuote":     yamlQuote,
+		"containerPath": containerPath,
 	}).Parse(embed.ComposeTemplate())
 	if err != nil {
 		return nil, fmt.Errorf("parse compose template: %w", err)
@@ -51,6 +52,17 @@ func GenerateCompose(params ComposeParams) ([]byte, error) {
 func yamlQuote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+// containerPath converts a host filesystem path to a Linux container path.
+// On Unix hosts the path is already valid; on Windows it converts
+// backslashes to forward slashes and turns "C:\foo" into "/C/foo".
+func containerPath(hostPath string) string {
+	p := strings.ReplaceAll(hostPath, `\`, "/")
+	if len(p) >= 2 && p[1] == ':' {
+		p = "/" + string(p[0]) + p[2:]
+	}
+	return p
 }
 
 func WriteComposeFile(params ComposeParams, destPath string) error {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/compose-spec/compose-go/v2/format"
 	"github.com/seznam/jailoc/internal/embed"
 )
 
@@ -69,31 +70,33 @@ func containerPath(hostPath string) string {
 }
 
 // splitMountSpec splits a mount spec string (host:container[:mode]) into its
-// parts, handling Windows drive-letter prefixes in the host path where the
-// colon after the drive letter is part of the path, not a field separator.
-// Only drive-absolute paths (e.g. C:\foo, D:/bar) are recognised; a path
-// separator must follow the colon to avoid mis-parsing specs like "a:/container".
+// parts, handling Windows drive-letter prefixes via format.ParseVolume.
 func splitMountSpec(spec string) (host, container, mode string, ok bool) {
-	s := spec
-	hostPrefix := ""
-	if len(s) >= 3 && s[1] == ':' && (s[2] == '\\' || s[2] == '/') &&
-		((s[0] >= 'a' && s[0] <= 'z') || (s[0] >= 'A' && s[0] <= 'Z')) {
-		hostPrefix = s[:2]
-		s = s[2:]
+	// format.ParseVolume rejects empty source sections;
+	// handle removal specs (e.g. ":/container:ro") separately.
+	if strings.HasPrefix(spec, ":") {
+		rest := spec[1:]
+		parts := strings.SplitN(rest, ":", 2)
+		if len(parts) == 0 || parts[0] == "" {
+			return "", "", "", false
+		}
+		m := "rw"
+		if len(parts) == 2 {
+			m = parts[1]
+		}
+		return "", parts[0], m, true
 	}
 
-	parts := strings.SplitN(s, ":", 3)
-	if len(parts) < 2 {
+	vol, err := format.ParseVolume(spec)
+	if err != nil || vol.Target == "" {
 		return "", "", "", false
 	}
 
-	host = hostPrefix + parts[0]
-	container = parts[1]
-	mode = "rw"
-	if len(parts) == 3 {
-		mode = parts[2]
+	m := "rw"
+	if vol.ReadOnly {
+		m = "ro"
 	}
-	return host, container, mode, true
+	return vol.Source, vol.Target, m, true
 }
 
 func WriteComposeFile(params ComposeParams, destPath string) error {

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -56,10 +56,9 @@ func yamlQuote(s string) string {
 }
 
 // containerPath converts a host filesystem path to a Linux container path.
-// On Unix hosts the path is already valid; on Windows it converts
-// backslashes to forward slashes and turns "C:\foo" into "/C/foo".
-// Only absolute drive paths (e.g. C:\foo, D:/bar) are rewritten;
-// drive-relative paths like "C:foo" are left unchanged.
+// It unconditionally normalizes backslashes to forward slashes and on
+// Windows turns absolute drive paths (e.g. C:\foo, D:/bar) into "/C/foo".
+// Drive-relative paths like "C:foo" are left unchanged.
 func containerPath(hostPath string) string {
 	p := strings.ReplaceAll(hostPath, `\`, "/")
 	if len(p) >= 3 && p[1] == ':' && p[2] == '/' &&

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -764,6 +764,18 @@ func TestMountsContainTarget(t *testing.T) {
 			containerPath: "/home/agent/.cache",
 			want:          false,
 		},
+		{
+			name:          "windows drive letter host",
+			mounts:        []string{`C:\Users\me\cfg:/home/agent/.config/opencode:rw`},
+			containerPath: "/home/agent/.config/opencode",
+			want:          true,
+		},
+		{
+			name:          "windows drive letter no match",
+			mounts:        []string{`C:\Users\me\cfg:/home/agent/.local:rw`},
+			containerPath: "/home/agent/.config/opencode",
+			want:          false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1006,6 +1018,27 @@ func TestReadOnlyMountCoversPath(t *testing.T) {
 			wantHost:      "/host/cfg/opencode",
 			wantCovered:   true,
 		},
+		{
+			name:          "windows drive letter exact match ro",
+			mounts:        []string{`C:\Users\me\cfg:/home/agent/.config/opencode:ro`},
+			containerPath: "/home/agent/.config/opencode",
+			wantHost:      `C:\Users\me\cfg`,
+			wantCovered:   true,
+		},
+		{
+			name:          "windows drive letter parent ro",
+			mounts:        []string{`C:\Users\me\cfg:/home/agent/.config:ro`},
+			containerPath: "/home/agent/.config/opencode",
+			wantHost:      `C:\Users\me\cfg/opencode`,
+			wantCovered:   true,
+		},
+		{
+			name:          "windows drive letter rw not covered",
+			mounts:        []string{`C:\Users\me\cfg:/home/agent/.config/opencode:rw`},
+			containerPath: "/home/agent/.config/opencode",
+			wantHost:      "",
+			wantCovered:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1054,6 +1087,11 @@ func TestContainerPath(t *testing.T) {
 			name: "empty string",
 			host: "",
 			want: "",
+		},
+		{
+			name: "drive-relative path unchanged",
+			host: "C:foo",
+			want: "C:foo",
 		},
 	}
 

--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -1021,3 +1021,75 @@ func TestReadOnlyMountCoversPath(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "unix path unchanged",
+			host: "/Users/test/work/project",
+			want: "/Users/test/work/project",
+		},
+		{
+			name: "windows drive letter",
+			host: `C:\Users\filip\git\project`,
+			want: "/C/Users/filip/git/project",
+		},
+		{
+			name: "windows lowercase drive",
+			host: `d:\repos\app`,
+			want: "/d/repos/app",
+		},
+		{
+			name: "windows forward slashes",
+			host: "C:/Users/filip/git/project",
+			want: "/C/Users/filip/git/project",
+		},
+		{
+			name: "empty string",
+			host: "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := containerPath(tt.host)
+			if got != tt.want {
+				t.Errorf("containerPath(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateComposeWindowsPaths(t *testing.T) {
+	t.Parallel()
+
+	params := ComposeParams{
+		WorkspaceName:  "wintest",
+		Port:           4096,
+		Image:          "ghcr.io/seznam/jailoc:test",
+		Paths:          []string{`C:\Users\filip\git\project`},
+		CPU:            2.0,
+		Memory:         "4g",
+		UseDataVolume:  true,
+		UseCacheVolume: true,
+		ExposePort:     true,
+	}
+
+	out, err := GenerateCompose(params)
+	if err != nil {
+		t.Fatalf("GenerateCompose returned error: %v", err)
+	}
+
+	rendered := string(out)
+
+	assertContains(t, rendered, `- C:\Users\filip\git\project:/C/Users/filip/git/project`)
+	assertContains(t, rendered, "working_dir: /C/Users/filip/git/project")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,11 +353,13 @@ func validateEnvFiles(paths []string, context string) error {
 }
 
 func ParseMount(spec string) (Mount, error) {
-	// Handle Windows drive-letter paths (e.g., C:\Users\...) where the colon
-	// after the drive letter is part of the host path, not a field separator.
+	// Handle Windows drive-letter paths (e.g., C:\Users\... or C:/Users/...)
+	// where the colon after the drive letter is part of the host path, not a
+	// field separator. Only match when a path separator follows the colon to
+	// avoid mis-parsing specs like "a:/container".
 	splitSpec := spec
 	hostPrefix := ""
-	if len(spec) >= 2 && spec[1] == ':' &&
+	if len(spec) >= 3 && spec[1] == ':' && (spec[2] == '\\' || spec[2] == '/') &&
 		((spec[0] >= 'a' && spec[0] <= 'z') || (spec[0] >= 'A' && spec[0] <= 'Z')) {
 		hostPrefix = spec[:2]
 		splitSpec = spec[2:]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,7 +311,7 @@ func validateDockerfileSource(value, fieldName string) error {
 	}
 
 	// Anything else is invalid
-	return fmt.Errorf("%s: must be an absolute path or HTTP(S) URL, got %q", fieldName, value)
+	return fmt.Errorf("%s: must be an absolute path, ~ home path, or HTTP(S) URL, got %q", fieldName, value)
 }
 
 func validateEnvEntries(entries []string, context string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/compose-spec/compose-go/v2/format"
 	"github.com/fatih/color"
 )
 
@@ -353,30 +354,32 @@ func validateEnvFiles(paths []string, context string) error {
 }
 
 func ParseMount(spec string) (Mount, error) {
-	// Handle Windows drive-letter paths (e.g., C:\Users\... or C:/Users/...)
-	// where the colon after the drive letter is part of the host path, not a
-	// field separator. Only match when a path separator follows the colon to
-	// avoid mis-parsing specs like "a:/container".
-	splitSpec := spec
-	hostPrefix := ""
-	if len(spec) >= 3 && spec[1] == ':' && (spec[2] == '\\' || spec[2] == '/') &&
-		((spec[0] >= 'a' && spec[0] <= 'z') || (spec[0] >= 'A' && spec[0] <= 'Z')) {
-		hostPrefix = spec[:2]
-		splitSpec = spec[2:]
+	// Handle removal specs (e.g. ":/container" or ":/container:ro").
+	// format.ParseVolume rejects empty source sections.
+	if strings.HasPrefix(spec, ":") {
+		return parseRemovalMount(spec)
 	}
 
-	parts := strings.Split(splitSpec, ":")
-	if len(parts) < 2 || len(parts) > 3 {
+	vol, err := format.ParseVolume(spec)
+	if err != nil {
+		return Mount{}, fmt.Errorf("invalid mount spec %q: %w", spec, err)
+	}
+
+	// ParseVolume accepts single-component specs as anonymous volumes;
+	// jailoc requires both host and container.
+	if vol.Source == "" || vol.Target == "" {
 		return Mount{}, fmt.Errorf("invalid mount spec %q: expected host:container[:mode]", spec)
 	}
 
-	host := hostPrefix + parts[0]
-	container := parts[1]
-	mode := "rw"
-	if len(parts) == 3 {
-		mode = parts[2]
-	}
+	host := vol.Source
+	container := vol.Target
 
+	// ParseVolume silently drops unknown mode options. Re-validate from the
+	// raw spec to reject anything other than ro/rw.
+	mode := rawMode(spec, host, container)
+	if mode == "" {
+		mode = "rw"
+	}
 	if mode != "ro" && mode != "rw" {
 		return Mount{}, fmt.Errorf("invalid mount spec %q: mode must be ro or rw", spec)
 	}
@@ -400,6 +403,46 @@ func ParseMount(spec string) (Mount, error) {
 	}
 
 	return Mount{Host: host, Container: container, Mode: mode}, nil
+}
+
+// parseRemovalMount handles mount specs with empty host (e.g. ":/container:ro")
+// that override an inherited mount by removing it or changing its mode.
+func parseRemovalMount(spec string) (Mount, error) {
+	rest := spec[1:]
+	parts := strings.SplitN(rest, ":", 2)
+	container := parts[0]
+	mode := "rw"
+	if len(parts) == 2 {
+		mode = parts[1]
+	}
+
+	if mode != "ro" && mode != "rw" {
+		return Mount{}, fmt.Errorf("invalid mount spec %q: mode must be ro or rw", spec)
+	}
+
+	expandedContainer, err := ExpandPath(container)
+	if err != nil {
+		return Mount{}, fmt.Errorf("expand mount container path %q: %w", container, err)
+	}
+	if !strings.HasPrefix(expandedContainer, "/") {
+		return Mount{}, fmt.Errorf("invalid mount spec %q: container path %q must be absolute (start with /)", spec, container)
+	}
+
+	return Mount{Host: "", Container: container, Mode: mode}, nil
+}
+
+// rawMode extracts the raw mode string from a mount spec, given the source and
+// target parsed by format.ParseVolume. Returns "" if no mode was specified.
+func rawMode(spec, source, target string) string {
+	prefix := source + ":" + target
+	if !strings.HasPrefix(spec, prefix) {
+		return ""
+	}
+	rest := spec[len(prefix):]
+	if len(rest) > 0 && rest[0] == ':' {
+		return rest[1:]
+	}
+	return ""
 }
 
 func validateMountHostPath(host string, context string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -405,8 +405,8 @@ func ParseMount(spec string) (Mount, error) {
 	return Mount{Host: host, Container: container, Mode: mode}, nil
 }
 
-// parseRemovalMount handles mount specs with empty host (e.g. ":/container:ro")
-// that override an inherited mount by removing it or changing its mode.
+// parseRemovalMount handles mount specs with empty host (e.g. ":/container")
+// that override an inherited mount by removing it.
 func parseRemovalMount(spec string) (Mount, error) {
 	rest := spec[1:]
 	parts := strings.SplitN(rest, ":", 2)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,12 +353,22 @@ func validateEnvFiles(paths []string, context string) error {
 }
 
 func ParseMount(spec string) (Mount, error) {
-	parts := strings.Split(spec, ":")
+	// Handle Windows drive-letter paths (e.g., C:\Users\...) where the colon
+	// after the drive letter is part of the host path, not a field separator.
+	splitSpec := spec
+	hostPrefix := ""
+	if len(spec) >= 2 && spec[1] == ':' &&
+		((spec[0] >= 'a' && spec[0] <= 'z') || (spec[0] >= 'A' && spec[0] <= 'Z')) {
+		hostPrefix = spec[:2]
+		splitSpec = spec[2:]
+	}
+
+	parts := strings.Split(splitSpec, ":")
 	if len(parts) < 2 || len(parts) > 3 {
 		return Mount{}, fmt.Errorf("invalid mount spec %q: expected host:container[:mode]", spec)
 	}
 
-	host := parts[0]
+	host := hostPrefix + parts[0]
 	container := parts[1]
 	mode := "rw"
 	if len(parts) == 3 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -385,7 +385,7 @@ func ParseMount(spec string) (Mount, error) {
 			return Mount{}, fmt.Errorf("expand mount host path %q: %w", host, err)
 		}
 		if !filepath.IsAbs(expandedHost) {
-			return Mount{}, fmt.Errorf("invalid mount spec %q: host path %q must be absolute", spec, host)
+			return Mount{}, fmt.Errorf("invalid mount spec %q: host path %q must be an absolute path or ~ home path", spec, host)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,8 +287,8 @@ func validateDockerfileSource(value, fieldName string) error {
 		return nil
 	}
 
-	// Absolute local paths starting with / are allowed
-	if strings.HasPrefix(value, "/") {
+	// Absolute local paths are allowed
+	if filepath.IsAbs(value) {
 		return nil
 	}
 
@@ -332,8 +332,8 @@ func validateEnvEntries(entries []string, context string) error {
 
 func validateEnvFiles(paths []string, context string) error {
 	for _, p := range paths {
-		if !strings.HasPrefix(p, "/") {
-			return fmt.Errorf("%s: env_file path %q must be absolute (start with /)", context, p)
+		if !filepath.IsAbs(p) {
+			return fmt.Errorf("%s: env_file path %q must be absolute", context, p)
 		}
 		if _, err := os.Stat(p); err != nil {
 			if os.IsNotExist(err) {
@@ -374,8 +374,8 @@ func ParseMount(spec string) (Mount, error) {
 		if err != nil {
 			return Mount{}, fmt.Errorf("expand mount host path %q: %w", host, err)
 		}
-		if !strings.HasPrefix(expandedHost, "/") {
-			return Mount{}, fmt.Errorf("invalid mount spec %q: host path %q must be absolute (start with / or ~)", spec, host)
+		if !filepath.IsAbs(expandedHost) {
+			return Mount{}, fmt.Errorf("invalid mount spec %q: host path %q must be absolute", spec, host)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -311,7 +311,7 @@ func validateDockerfileSource(value, fieldName string) error {
 	}
 
 	// Anything else is invalid
-	return fmt.Errorf("%s: must be an absolute path (/..., ~/...) or HTTP(S) URL, got %q", fieldName, value)
+	return fmt.Errorf("%s: must be an absolute path or HTTP(S) URL, got %q", fieldName, value)
 }
 
 func validateEnvEntries(entries []string, context string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -2345,6 +2346,73 @@ func TestParseMountInvalid(t *testing.T) {
 	}
 
 	for _, spec := range invalidSpecs {
+		t.Run(spec, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := ParseMount(spec); err == nil {
+				t.Fatalf("expected ParseMount(%q) to fail", spec)
+			}
+		})
+	}
+}
+
+func TestParseMountWindowsPaths(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-only path parsing test")
+	}
+	t.Parallel()
+
+	valid := []struct {
+		name      string
+		spec      string
+		host      string
+		container string
+		mode      string
+	}{
+		{
+			name:      "backslash path",
+			spec:      `C:\Users\foo:/container:rw`,
+			host:      `C:\Users\foo`,
+			container: "/container",
+			mode:      "rw",
+		},
+		{
+			name:      "forward slash path",
+			spec:      "D:/projects/app:/home/agent/app:ro",
+			host:      "D:/projects/app",
+			container: "/home/agent/app",
+			mode:      "ro",
+		},
+		{
+			name:      "implicit rw",
+			spec:      `C:\Users\foo\project:/home/agent/project`,
+			host:      `C:\Users\foo\project`,
+			container: "/home/agent/project",
+			mode:      "rw",
+		},
+	}
+
+	for _, tt := range valid {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseMount(tt.spec)
+			if err != nil {
+				t.Fatalf("ParseMount(%q) failed: %v", tt.spec, err)
+			}
+
+			if got.Host != tt.host || got.Container != tt.container || got.Mode != tt.mode {
+				t.Fatalf("ParseMount(%q) = %#v, want host=%q container=%q mode=%q", tt.spec, got, tt.host, tt.container, tt.mode)
+			}
+		})
+	}
+
+	invalid := []string{
+		`C:\a:/b:invalid`,
+		`C:\a:/b:ro:extra`,
+	}
+
+	for _, spec := range invalid {
 		t.Run(spec, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/docker/fetch.go
+++ b/internal/docker/fetch.go
@@ -25,7 +25,7 @@ func detectSourceType(value string) (sourceType, error) {
 	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
 		return sourceHTTP, nil
 	}
-	return 0, fmt.Errorf("unsupported dockerfile source %q: must be an absolute local path or HTTP(S) URL", value)
+	return 0, fmt.Errorf("unsupported dockerfile source %q: must be an absolute local path, a ~/path, or an HTTP(S) URL", value)
 }
 
 func readLocalDockerfile(path string) ([]byte, error) {

--- a/internal/docker/fetch.go
+++ b/internal/docker/fetch.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -18,13 +19,13 @@ const (
 )
 
 func detectSourceType(value string) (sourceType, error) {
-	if strings.HasPrefix(value, "/") || strings.HasPrefix(value, "~") {
+	if filepath.IsAbs(value) || strings.HasPrefix(value, "~") {
 		return sourceLocal, nil
 	}
 	if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
 		return sourceHTTP, nil
 	}
-	return 0, fmt.Errorf("unsupported dockerfile source %q: must be an absolute local path (/..., ~/...) or HTTP(S) URL", value)
+	return 0, fmt.Errorf("unsupported dockerfile source %q: must be an absolute local path or HTTP(S) URL", value)
 }
 
 func readLocalDockerfile(path string) ([]byte, error) {

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -10,7 +10,7 @@ services:
 {{- end}}
     volumes:
 {{- range .Paths}}
-      - {{.}}:{{.}}
+      - {{.}}:{{. | containerPath}}
 {{- end}}
 {{- if .UseDataVolume}}
       - opencode-data-{{.WorkspaceName}}:/home/agent/.local/share/opencode
@@ -76,7 +76,7 @@ services:
     entrypoint: ["/usr/local/bin/entrypoint.sh"]
     command: ["opencode", "serve", "--hostname", "0.0.0.0", "--port", "4096", "--print-logs", "--log-level", "DEBUG"]
 {{- if .Paths}}
-    working_dir: {{index .Paths 0}}
+    working_dir: {{index .Paths 0 | containerPath}}
 {{- end}}
     healthcheck:
       test: ["CMD-SHELL", "curl -sf -u \"opencode:$$OPENCODE_SERVER_PASSWORD\" http://localhost:4096/global/health || exit 1"]


### PR DESCRIPTION
## Summary

- Replace `strings.HasPrefix(_, "/")` with `filepath.IsAbs()` for host-path validation in `ParseMount`, `validateDockerfileSource`, and `validateEnvFiles`
- On Windows, `os.UserHomeDir()` returns `C:\Users\...` which doesn't start with `/`, causing default mounts with `~` to fail validation
- Container-path checks (always Linux) left unchanged