### PR TITLE
fix(tui): set explicit opencode theme in container tui.json

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -377,8 +377,9 @@ func writeTUIConfig(baseDir string) error {
 }
 
 func writeTUIJSON(path, specifier string) error {
-	config := map[string][]string{
-		"plugin": {specifier},
+	config := map[string]any{
+		"theme":  "opencode",
+		"plugin": []string{specifier},
 	}
 
 	data, err := json.Marshal(config)

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -543,18 +543,27 @@ func TestWriteTUIConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("os.ReadFile(%q) failed: %v", path, err)
 		}
-		var config map[string][]string
+		var config map[string]any
 		if err := json.Unmarshal(data, &config); err != nil {
 			t.Fatalf("json.Unmarshal(%q) failed: %v", path, err)
 		}
-		plugins, ok := config["plugin"]
+		theme, ok := config["theme"]
+		if !ok {
+			t.Fatalf("%s missing 'theme' key", path)
+		}
+		if theme != "opencode" {
+			t.Fatalf("%s: theme = %q, want %q", path, theme, "opencode")
+		}
+		pluginsRaw, ok := config["plugin"]
 		if !ok {
 			t.Fatalf("%s missing 'plugin' key", path)
 		}
-		if len(plugins) != 1 {
-			t.Fatalf("%s: expected 1 plugin, got %d", path, len(plugins))
+		plugins, ok := pluginsRaw.([]any)
+		if !ok || len(plugins) != 1 {
+			t.Fatalf("%s: expected 1 plugin, got %v", path, pluginsRaw)
 		}
-		return plugins[0]
+		s, _ := plugins[0].(string)
+		return s
 	}
 
 	wantHost := "file://" + filepath.Join(tmpDir, "tui-plugin")

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -382,14 +382,20 @@ func (c *Client) ExecInteractive(ctx context.Context, containerID string, args [
 		}()
 	}
 
+	connWriter := &syncWriter{w: attachResp.Conn}
+
 	if stdin != nil {
 		go func() {
-			_, _ = io.Copy(attachResp.Conn, stdin)
+			_, _ = io.Copy(connWriter, stdin)
 			_ = attachResp.CloseWrite()
 		}()
 	}
 
-	_, copyErr := io.Copy(stdout, attachResp.Reader)
+	palette := newPaletteResponder(stdout, connWriter)
+	_, copyErr := io.Copy(palette, attachResp.Reader)
+	if ferr := palette.Flush(); ferr != nil && copyErr == nil {
+		copyErr = ferr
+	}
 
 	// Exec finished — close connection to unblock the stdin goroutine if
 	// it's in Conn.Write(). If blocked in os.Stdin.Read() (uninterruptible),

--- a/internal/docker/palette.go
+++ b/internal/docker/palette.go
@@ -1,0 +1,212 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// githubDarkPalette defines the ANSI 16-color palette for the GitHub Dark
+// Default terminal theme. OpenCode's "opencode" theme derives its background
+// scale from the terminal palette queried via OSC 4. When running inside a
+// Docker container the round-trip latency causes the query to time out,
+// producing neutral gray backgrounds. By responding to OSC 4 queries
+// immediately with this palette, the expected blue-tinted backgrounds appear.
+var githubDarkPalette = [16][3]byte{
+	{0x48, 0x4f, 0x58}, // 0:  Black
+	{0xff, 0x7b, 0x72}, // 1:  Red
+	{0x3f, 0xb9, 0x50}, // 2:  Green
+	{0xd2, 0x99, 0x22}, // 3:  Yellow
+	{0x58, 0xa6, 0xff}, // 4:  Blue
+	{0xbc, 0x8c, 0xff}, // 5:  Magenta
+	{0x39, 0xc5, 0xcf}, // 6:  Cyan
+	{0xb1, 0xba, 0xc4}, // 7:  White
+	{0x6e, 0x76, 0x81}, // 8:  Bright Black
+	{0xff, 0xa1, 0x98}, // 9:  Bright Red
+	{0x56, 0xd3, 0x64}, // 10: Bright Green
+	{0xe3, 0xb3, 0x41}, // 11: Bright Yellow
+	{0x79, 0xc0, 0xff}, // 12: Bright Blue
+	{0xd2, 0xa8, 0xff}, // 13: Bright Magenta
+	{0x56, 0xd4, 0xdd}, // 14: Bright Cyan
+	{0xf0, 0xf6, 0xfc}, // 15: Bright White
+}
+
+// osc4Prefix is the byte sequence that starts an OSC 4 palette query.
+var osc4Prefix = []byte("\x1b]4;")
+
+// maxOSC4QueryLen is the maximum length of a complete OSC 4 query:
+// \x1b]4;NNN;?\x1b\ = 4 + 3 + 2 + 2 = 11 bytes.
+const maxOSC4QueryLen = 11
+
+// paletteResponder intercepts OSC 4 palette queries in the container's stdout
+// stream and writes immediate responses to the container's stdin. Queries for
+// color indices 0-15 are suppressed from the downstream output to prevent
+// double-responses from the host terminal. All other data passes through
+// unchanged.
+type paletteResponder struct {
+	downstream io.Writer
+	respond    io.Writer
+	buf        []byte
+}
+
+func newPaletteResponder(downstream, respond io.Writer) *paletteResponder {
+	return &paletteResponder{
+		downstream: downstream,
+		respond:    respond,
+	}
+}
+
+func (r *paletteResponder) Write(p []byte) (int, error) {
+	data := append(r.buf, p...) //nolint:gocritic // intentional merge of buf and p
+	r.buf = r.buf[:0]
+
+	for len(data) > 0 {
+		idx := bytes.Index(data, osc4Prefix)
+		if idx < 0 {
+			keep := partialSuffix(data, osc4Prefix)
+			flush := data[:len(data)-keep]
+			if len(flush) > 0 {
+				if err := writeAll(r.downstream, flush); err != nil {
+					return len(p), err
+				}
+			}
+			r.buf = append(r.buf[:0], data[len(data)-keep:]...)
+			break
+		}
+
+		if idx > 0 {
+			if err := writeAll(r.downstream, data[:idx]); err != nil {
+				return len(p), err
+			}
+		}
+
+		rest := data[idx:]
+		colorIdx, seqLen, ok := parseOSC4Query(rest)
+		switch {
+		case ok && colorIdx < 16:
+			_, _ = r.respond.Write(formatOSC4Response(colorIdx))
+			data = rest[seqLen:]
+		case ok:
+			if err := writeAll(r.downstream, rest[:seqLen]); err != nil {
+				return len(p), err
+			}
+			data = rest[seqLen:]
+		case len(rest) < maxOSC4QueryLen:
+			r.buf = append(r.buf[:0], rest...)
+			return len(p), nil
+		default:
+			if err := writeAll(r.downstream, osc4Prefix); err != nil {
+				return len(p), err
+			}
+			data = rest[len(osc4Prefix):]
+		}
+	}
+
+	return len(p), nil
+}
+
+// Flush writes any buffered partial-match bytes to the downstream writer.
+func (r *paletteResponder) Flush() error {
+	if len(r.buf) > 0 {
+		err := writeAll(r.downstream, r.buf)
+		r.buf = r.buf[:0]
+		return err
+	}
+	return nil
+}
+
+// parseOSC4Query parses an OSC 4 query starting at the beginning of data.
+// Returns (colorIndex, sequenceLength, ok). The expected format is:
+//
+//	\x1b]4;<digits>;?<terminator>
+//
+// where terminator is \x07 (BEL) or \x1b\\ (ST).
+func parseOSC4Query(data []byte) (int, int, bool) {
+	if len(data) < len(osc4Prefix) {
+		return 0, 0, false
+	}
+
+	pos := len(osc4Prefix)
+
+	digitStart := pos
+	for pos < len(data) && data[pos] >= '0' && data[pos] <= '9' {
+		pos++
+	}
+	if pos == digitStart || pos-digitStart > 3 {
+		return 0, 0, false
+	}
+
+	colorIdx := 0
+	for _, b := range data[digitStart:pos] {
+		colorIdx = colorIdx*10 + int(b-'0')
+	}
+
+	if pos+2 > len(data) {
+		return 0, 0, false
+	}
+	if data[pos] != ';' || data[pos+1] != '?' {
+		return 0, 0, false
+	}
+	pos += 2
+
+	if pos >= len(data) {
+		return 0, 0, false
+	}
+	if data[pos] == '\x07' {
+		return colorIdx, pos + 1, true
+	}
+	if data[pos] == '\x1b' {
+		if pos+1 >= len(data) {
+			return 0, 0, false
+		}
+		if data[pos+1] == '\\' {
+			return colorIdx, pos + 2, true
+		}
+	}
+
+	return 0, 0, false
+}
+
+// formatOSC4Response builds an OSC 4 response for the given color index using
+// the GitHub Dark palette. The format is: \x1b]4;<N>;rgb:<RRRR>/<GGGG>/<BBBB>\x07
+// with 8-bit values expanded to 16-bit by duplication (0xAB → 0xABAB).
+func formatOSC4Response(colorIdx int) []byte {
+	c := githubDarkPalette[colorIdx]
+	return fmt.Appendf(nil, "\x1b]4;%d;rgb:%02x%02x/%02x%02x/%02x%02x\x07",
+		colorIdx, c[0], c[0], c[1], c[1], c[2], c[2])
+}
+
+// partialSuffix returns how many bytes at the end of data could be the start
+// of target. Used to avoid splitting a match across Write boundaries.
+func partialSuffix(data, target []byte) int {
+	for i := 1; i < len(target) && i <= len(data); i++ {
+		if bytes.Equal(data[len(data)-i:], target[:i]) {
+			return i
+		}
+	}
+	return 0
+}
+
+// writeAll writes all of p to w, retrying short writes.
+func writeAll(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		p = p[n:]
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (sw *syncWriter) Write(p []byte) (int, error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.w.Write(p)
+}

--- a/internal/docker/palette_test.go
+++ b/internal/docker/palette_test.go
@@ -1,0 +1,279 @@
+package docker
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseOSC4Query(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []byte
+		wantIdx  int
+		wantLen  int
+		wantOK   bool
+	}{
+		{
+			name:    "color 0 BEL terminator",
+			input:   []byte("\x1b]4;0;?\x07"),
+			wantIdx: 0, wantLen: 8, wantOK: true,
+		},
+		{
+			name:    "color 15 BEL terminator",
+			input:   []byte("\x1b]4;15;?\x07"),
+			wantIdx: 15, wantLen: 9, wantOK: true,
+		},
+		{
+			name:    "color 255 BEL terminator",
+			input:   []byte("\x1b]4;255;?\x07"),
+			wantIdx: 255, wantLen: 10, wantOK: true,
+		},
+		{
+			name:    "color 7 ST terminator",
+			input:   []byte("\x1b]4;7;?\x1b\\"),
+			wantIdx: 7, wantLen: 9, wantOK: true,
+		},
+		{
+			name:  "missing terminator",
+			input: []byte("\x1b]4;0;?"),
+			wantOK: false,
+		},
+		{
+			name:  "no digits",
+			input: []byte("\x1b]4;;?\x07"),
+			wantOK: false,
+		},
+		{
+			name:  "too many digits",
+			input: []byte("\x1b]4;1234;?\x07"),
+			wantOK: false,
+		},
+		{
+			name:  "wrong separator",
+			input: []byte("\x1b]4;0:?\x07"),
+			wantOK: false,
+		},
+		{
+			name:  "too short",
+			input: []byte("\x1b]4"),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotIdx, gotLen, gotOK := parseOSC4Query(tt.input)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if !gotOK {
+				return
+			}
+			if gotIdx != tt.wantIdx {
+				t.Errorf("colorIdx = %d, want %d", gotIdx, tt.wantIdx)
+			}
+			if gotLen != tt.wantLen {
+				t.Errorf("seqLen = %d, want %d", gotLen, tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestFormatOSC4Response(t *testing.T) {
+	t.Parallel()
+
+	got := string(formatOSC4Response(0))
+	want := "\x1b]4;0;rgb:4848/4f4f/5858\x07"
+	if got != want {
+		t.Errorf("formatOSC4Response(0) = %q, want %q", got, want)
+	}
+
+	got = string(formatOSC4Response(4))
+	want = "\x1b]4;4;rgb:5858/a6a6/ffff\x07"
+	if got != want {
+		t.Errorf("formatOSC4Response(4) = %q, want %q", got, want)
+	}
+}
+
+func TestPaletteResponderPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var downstream, respond bytes.Buffer
+	pr := newPaletteResponder(&downstream, &respond)
+
+	data := []byte("hello world\x1b[31mred text\x1b[0m")
+	n, err := pr.Write(data)
+	if err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("Write n = %d, want %d", n, len(data))
+	}
+	if err := pr.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if downstream.String() != string(data) {
+		t.Errorf("downstream = %q, want %q", downstream.String(), string(data))
+	}
+	if respond.Len() != 0 {
+		t.Errorf("respond should be empty, got %q", respond.String())
+	}
+}
+
+func TestPaletteResponderInterceptsQuery(t *testing.T) {
+	t.Parallel()
+
+	var downstream, respond bytes.Buffer
+	pr := newPaletteResponder(&downstream, &respond)
+
+	data := []byte("before\x1b]4;0;?\x07after")
+	if _, err := pr.Write(data); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := pr.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if downstream.String() != "beforeafter" {
+		t.Errorf("downstream = %q, want %q", downstream.String(), "beforeafter")
+	}
+
+	wantResp := "\x1b]4;0;rgb:4848/4f4f/5858\x07"
+	if respond.String() != wantResp {
+		t.Errorf("respond = %q, want %q", respond.String(), wantResp)
+	}
+}
+
+func TestPaletteResponderMultipleQueries(t *testing.T) {
+	t.Parallel()
+
+	var downstream, respond bytes.Buffer
+	pr := newPaletteResponder(&downstream, &respond)
+
+	data := []byte("\x1b]4;0;?\x07\x1b]4;4;?\x07\x1b]4;15;?\x07")
+	if _, err := pr.Write(data); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := pr.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if downstream.Len() != 0 {
+		t.Errorf("downstream should be empty, got %q", downstream.String())
+	}
+
+	responses := respond.String()
+	if !strings.Contains(responses, "\x1b]4;0;rgb:4848/4f4f/5858\x07") {
+		t.Error("missing response for color 0")
+	}
+	if !strings.Contains(responses, "\x1b]4;4;rgb:5858/a6a6/ffff\x07") {
+		t.Error("missing response for color 4")
+	}
+	if !strings.Contains(responses, "\x1b]4;15;rgb:f0f0/f6f6/fcfc\x07") {
+		t.Error("missing response for color 15")
+	}
+}
+
+func TestPaletteResponderPartialSequence(t *testing.T) {
+	t.Parallel()
+
+	var downstream, respond bytes.Buffer
+	pr := newPaletteResponder(&downstream, &respond)
+
+	if _, err := pr.Write([]byte("data\x1b]4;")); err != nil {
+		t.Fatalf("Write 1 error: %v", err)
+	}
+	if _, err := pr.Write([]byte("3;?\x07more")); err != nil {
+		t.Fatalf("Write 2 error: %v", err)
+	}
+	if err := pr.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if downstream.String() != "datamore" {
+		t.Errorf("downstream = %q, want %q", downstream.String(), "datamore")
+	}
+
+	wantResp := "\x1b]4;3;rgb:d2d2/9999/2222\x07"
+	if respond.String() != wantResp {
+		t.Errorf("respond = %q, want %q", respond.String(), wantResp)
+	}
+}
+
+func TestPaletteResponderHighColorPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var downstream, respond bytes.Buffer
+	pr := newPaletteResponder(&downstream, &respond)
+
+	query := "\x1b]4;200;?\x07"
+	if _, err := pr.Write([]byte(query)); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := pr.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if downstream.String() != query {
+		t.Errorf("downstream = %q, want %q (high color should pass through)", downstream.String(), query)
+	}
+	if respond.Len() != 0 {
+		t.Errorf("respond should be empty for high color, got %q", respond.String())
+	}
+}
+
+func TestPaletteResponderSTTerminator(t *testing.T) {
+	t.Parallel()
+
+	var downstream, respond bytes.Buffer
+	pr := newPaletteResponder(&downstream, &respond)
+
+	data := []byte("x\x1b]4;7;?\x1b\\y")
+	if _, err := pr.Write(data); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := pr.Flush(); err != nil {
+		t.Fatalf("Flush error: %v", err)
+	}
+
+	if downstream.String() != "xy" {
+		t.Errorf("downstream = %q, want %q", downstream.String(), "xy")
+	}
+
+	wantResp := "\x1b]4;7;rgb:b1b1/baba/c4c4\x07"
+	if respond.String() != wantResp {
+		t.Errorf("respond = %q, want %q", respond.String(), wantResp)
+	}
+}
+
+func TestPartialSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		data   []byte
+		target []byte
+		want   int
+	}{
+		{"no match", []byte("hello"), []byte("\x1b]4;"), 0},
+		{"1-byte match", []byte("data\x1b"), []byte("\x1b]4;"), 1},
+		{"2-byte match", []byte("data\x1b]"), []byte("\x1b]4;"), 2},
+		{"3-byte match", []byte("data\x1b]4"), []byte("\x1b]4;"), 3},
+		{"full prefix not suffix", []byte("data\x1b]4;"), []byte("\x1b]4;"), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := partialSuffix(tt.data, tt.target)
+			if got != tt.want {
+				t.Errorf("partialSuffix = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Linux containers fall back to the `system` theme (neutral gray scale from terminal background) because they lack macOS dark mode detection APIs (NSAppearance). This produces washed-out colors compared to macOS.

Force the `opencode` theme explicitly in the generated `tui.json` so containers render with the same GitHub Dark palette that macOS uses natively.