### PR TITLE
feat(logging): add always-on debug file logging

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -17,6 +18,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/seznam/jailoc/internal/config"
 	"github.com/seznam/jailoc/internal/docker"
+	"github.com/seznam/jailoc/internal/logging"
 	"github.com/seznam/jailoc/internal/password"
 	"github.com/seznam/jailoc/internal/update"
 	"github.com/seznam/jailoc/internal/workspace"
@@ -37,6 +39,8 @@ var rootCmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.MaximumNArgs(1),
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+		_ = logging.Init()
+		slog.Info("jailoc started", "version", appVersion)
 		if noColor, _ := cmd.Flags().GetBool("no-color"); noColor {
 			color.NoColor = true
 		}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,6 +57,7 @@ func runUp(ctx context.Context, args []string) error {
 		}
 	}
 
+	slog.Debug("resolving workspace", "name", workspaceFlag, "explicit", workspaceExplicit)
 	ws, err := workspace.Resolve(cfg, workspaceFlag)
 	if err != nil {
 		return fmt.Errorf("resolve workspace %q: %w", workspaceFlag, err)
@@ -133,6 +135,7 @@ func runUp(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve image for workspace %q: %w", ws.Name, err)
 	}
+	slog.Debug("image resolved", "image", finalImage)
 
 	cacheDir := ComposeCacheDir(ws.Name)
 	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
@@ -172,25 +175,27 @@ func runUp(ctx context.Context, args []string) error {
 		Mounts:          ws.Mounts,
 		AllowedHosts:    ws.AllowedHosts,
 		AllowedNetworks: ws.AllowedNetworks,
-		Env:              ws.Env,
-		SSHAuthSock:      resolveSSHAuthSock(ws.SSHAuthSock),
-		SSHKnownHosts:    resolveSSHKnownHosts(ws.SSHAuthSock),
-		GitConfig:        resolveGitConfig(ws.GitConfig),
-		CPU:              ws.CPU,
-		Memory:           ws.Memory,
-		UseDataVolume:    !compose.MountsContainTarget(ws.Mounts, "/home/agent/.local/share/opencode"),
-		UseCacheVolume:   !compose.MountsContainTarget(ws.Mounts, "/home/agent/.cache"),
-		ExposePort:       ws.ExposePort,
-		EnableDocker:     ws.EnableDocker,
+		Env:             ws.Env,
+		SSHAuthSock:     resolveSSHAuthSock(ws.SSHAuthSock),
+		SSHKnownHosts:   resolveSSHKnownHosts(ws.SSHAuthSock),
+		GitConfig:       resolveGitConfig(ws.GitConfig),
+		CPU:             ws.CPU,
+		Memory:          ws.Memory,
+		UseDataVolume:   !compose.MountsContainTarget(ws.Mounts, "/home/agent/.local/share/opencode"),
+		UseCacheVolume:  !compose.MountsContainTarget(ws.Mounts, "/home/agent/.cache"),
+		ExposePort:      ws.ExposePort,
+		EnableDocker:    ws.EnableDocker,
 	}
 
 	_, _ = color.New(color.FgCyan).Printf("Generating compose configuration...\n")
 	if err := compose.WriteComposeFile(params, composePath); err != nil {
 		return fmt.Errorf("write compose file for workspace %q: %w", ws.Name, err)
 	}
+	slog.Info("compose file written", "path", composePath)
 
 	_, _ = color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
 	startClient := docker.NewClient(composePath, "", ws.Name)
+	slog.Debug("starting workspace", "name", ws.Name, "port", ws.Port)
 	if err := startClient.Up(ctx); err != nil {
 		return fmt.Errorf("start workspace %q: %w", ws.Name, err)
 	}
@@ -287,6 +292,7 @@ func ResolveAndLayerImage(ctx context.Context, cfg *config.Config, ws *workspace
 			return "", fmt.Errorf("resolve base image: %w", err)
 		}
 
+		slog.Debug("building workspace layer", "base", base, "dockerfile", ws.Dockerfile)
 		final, err := docker.BuildOverlayImage(ctx, base, *ws)
 		if err != nil {
 			return "", fmt.Errorf("build workspace overlay image: %w", err)

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -271,6 +271,7 @@ func resolveImageStrategy(wsImage, defaultsImage, wsDockerfile string) (imageStr
 
 func ResolveAndLayerImage(ctx context.Context, cfg *config.Config, ws *workspace.Resolved, version string) (string, error) {
 	strategy, strategyImage := resolveImageStrategy(ws.Image, cfg.Defaults.Image, ws.Dockerfile)
+	slog.Debug("image strategy resolved", "strategy", strategy, "image", strategyImage)
 	switch strategy {
 	case strategyDirectImage:
 		_, _ = color.New(color.FgCyan).Printf("Using workspace image %s\n", strategyImage)

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,23 +14,23 @@ import (
 )
 
 type ComposeParams struct {
-	WorkspaceName    string
-	Port             int
-	Image            string
-	Paths            []string
-	Mounts           []string
-	AllowedHosts     []string
-	AllowedNetworks  []string
-	Env []string
-	SSHAuthSock      string // host socket path to mount, empty = disabled
-	SSHKnownHosts    string // host known_hosts path to mount (bound to SSHAuthSock), empty = disabled
-	GitConfig        string // host gitconfig path to mount, empty = disabled
-	CPU              float64
-	Memory           string
-	UseDataVolume    bool
-	UseCacheVolume   bool
-	ExposePort       bool
-	EnableDocker     bool
+	WorkspaceName   string
+	Port            int
+	Image           string
+	Paths           []string
+	Mounts          []string
+	AllowedHosts    []string
+	AllowedNetworks []string
+	Env             []string
+	SSHAuthSock     string // host socket path to mount, empty = disabled
+	SSHKnownHosts   string // host known_hosts path to mount (bound to SSHAuthSock), empty = disabled
+	GitConfig       string // host gitconfig path to mount, empty = disabled
+	CPU             float64
+	Memory          string
+	UseDataVolume   bool
+	UseCacheVolume  bool
+	ExposePort      bool
+	EnableDocker    bool
 }
 
 func GenerateCompose(params ComposeParams) ([]byte, error) {
@@ -102,6 +103,8 @@ func splitMountSpec(spec string) (host, container, mode string, ok bool) {
 }
 
 func WriteComposeFile(params ComposeParams, destPath string) error {
+	slog.Debug("generating compose file", "workspace", params.WorkspaceName, "dest", destPath)
+
 	composeBytes, err := GenerateCompose(params)
 	if err != nil {
 		return fmt.Errorf("generate compose file content: %w", err)
@@ -110,6 +113,8 @@ func WriteComposeFile(params ComposeParams, destPath string) error {
 	if err := os.WriteFile(destPath, composeBytes, 0o600); err != nil {
 		return fmt.Errorf("write compose file to %q: %w", destPath, err)
 	}
+
+	slog.Debug("compose file written", "bytes", len(composeBytes))
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"net"
 	"net/url"
@@ -210,7 +211,17 @@ func ConfigPath() string {
 }
 
 func Load() (*Config, error) {
-	return loadFrom(ConfigPath(), true)
+	configPath := ConfigPath()
+	slog.Debug("loading config", "path", configPath)
+
+	cfg, err := loadFrom(configPath, true)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("config loaded", "workspaces", len(cfg.Workspaces))
+
+	return cfg, nil
 }
 
 func LoadFrom(path string) (*Config, error) {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -358,7 +358,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 			return "", fmt.Errorf("build preset image: %w", err)
 		}
 
-		slog.Info("base image resolved", "tag", tag)
+		slog.Debug("base image resolved", "tag", tag)
 		return tag, nil
 	}
 
@@ -374,7 +374,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 		return "", fmt.Errorf("build embedded base image: %w", err)
 	}
 
-	slog.Info("base image resolved", "tag", embeddedTag)
+	slog.Debug("base image resolved", "tag", embeddedTag)
 	return embeddedTag, nil
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,6 +76,8 @@ func NewClient(composeFile, workDir, workspace string) *Client {
 }
 
 func (c *Client) Up(ctx context.Context) error {
+	slog.Info("compose up", "workspace", c.workspace)
+
 	if err := c.initComposeSvc(); err != nil {
 		return err
 	}
@@ -101,6 +104,8 @@ func (c *Client) Up(ctx context.Context) error {
 }
 
 func (c *Client) Down(ctx context.Context) error {
+	slog.Info("compose down", "workspace", c.workspace)
+
 	if err := c.initComposeSvc(); err != nil {
 		return err
 	}
@@ -113,6 +118,8 @@ func (c *Client) Down(ctx context.Context) error {
 }
 
 func (c *Client) IsRunning(ctx context.Context) (bool, error) {
+	slog.Debug("checking container running status", "workspace", c.workspace)
+
 	container, err := c.opencodeContainer(ctx)
 	if err != nil {
 		return false, err
@@ -329,6 +336,8 @@ func (c *Client) initComposeSvc() error {
 }
 
 func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (string, error) {
+	slog.Debug("resolving base image", "version", version)
+
 	if cfg != nil && strings.TrimSpace(cfg.Base.Dockerfile) != "" {
 		source := strings.TrimSpace(cfg.Base.Dockerfile)
 		_, _ = color.New(color.FgCyan).Printf("Loading preset Dockerfile from %s...\n", source)
@@ -349,6 +358,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 			return "", fmt.Errorf("build preset image: %w", err)
 		}
 
+		slog.Info("base image resolved", "tag", tag)
 		return tag, nil
 	}
 
@@ -364,6 +374,7 @@ func ResolveBaseImage(ctx context.Context, cfg *config.Config, version string) (
 		return "", fmt.Errorf("build embedded base image: %w", err)
 	}
 
+	slog.Info("base image resolved", "tag", embeddedTag)
 	return embeddedTag, nil
 }
 
@@ -395,6 +406,9 @@ func buildEmbeddedImage(ctx context.Context, cli dockerclient.APIClient, tag str
 		return fmt.Errorf("create temp directory for embedded Dockerfile: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	buildContextDir := tmpDir
+	slog.Debug("building image", "tag", tag, "context", buildContextDir)
 
 	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
 	if err := os.WriteFile(dockerfilePath, embed.Dockerfile(), 0o600); err != nil {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -456,6 +456,7 @@ func buildPresetImage(ctx context.Context, cli dockerclient.APIClient, dockerfil
 
 	hash := sha256.Sum256(dockerfileContent)
 	presetTag := fmt.Sprintf("jailoc-base:preset-%x", hash[:8])
+	slog.Debug("building image", "tag", presetTag, "context", tmpDir)
 
 	buildCtx, err := archive.TarWithOptions(tmpDir, &archive.TarOptions{})
 	if err != nil {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -27,6 +27,7 @@ func TestNewClient(t *testing.T) {
 
 	if client == nil {
 		t.Fatal("expected non-nil client")
+		return
 	}
 	if client.composeFile != composeFile {
 		t.Fatalf("unexpected composeFile: got %q, want %q", client.composeFile, composeFile)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -9,10 +9,18 @@ import (
 
 const maxLogSize = 5 * 1024 * 1024 // 5MB
 
+// logFile tracks the current log file so repeated Init() calls do not leak FDs.
+var logFile *os.File
+
 // Init sets up file-based slog logging at ~/.cache/jailoc/jailoc.log.
 // On any failure it falls back to a discard handler and returns nil.
 // Never errors, never panics, never writes to stderr/stdout.
 func Init() error {
+	if logFile != nil {
+		_ = logFile.Close()
+		logFile = nil
+	}
+
 	logPath := logFilePath()
 
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o750); err != nil {
@@ -20,9 +28,11 @@ func Init() error {
 		return nil
 	}
 
-	// Rotate if over size cap
+	// Rotate if over size cap. If rename fails, truncate to enforce the limit.
 	if info, err := os.Stat(logPath); err == nil && info.Size() > maxLogSize {
-		_ = os.Rename(logPath, logPath+".1")
+		if err := os.Rename(logPath, logPath+".1"); err != nil {
+			_ = os.Truncate(logPath, 0)
+		}
 	}
 
 	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640) //nolint:gosec // G304: path derived from os.UserHomeDir(), not user input
@@ -31,6 +41,7 @@ func Init() error {
 		return nil
 	}
 
+	logFile = f
 	h := slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})
 	slog.SetDefault(slog.New(h))
 	return nil

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,49 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+const maxLogSize = 5 * 1024 * 1024 // 5MB
+
+// Init sets up file-based slog logging at ~/.cache/jailoc/jailoc.log.
+// On any failure it falls back to a discard handler and returns nil.
+// Never errors, never panics, never writes to stderr/stdout.
+func Init() error {
+	logPath := logFilePath()
+
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o750); err != nil {
+		setDiscard()
+		return nil
+	}
+
+	// Rotate if over size cap
+	if info, err := os.Stat(logPath); err == nil && info.Size() > maxLogSize {
+		_ = os.Rename(logPath, logPath+".1")
+	}
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640) //nolint:gosec // G304: path derived from os.UserHomeDir(), not user input
+	if err != nil {
+		setDiscard()
+		return nil
+	}
+
+	h := slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})
+	slog.SetDefault(slog.New(h))
+	return nil
+}
+
+func logFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.TempDir()
+	}
+	return filepath.Join(home, ".cache", "jailoc", "jailoc.log")
+}
+
+func setDiscard() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -50,7 +50,7 @@ func Init() error {
 func logFilePath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		home = os.TempDir()
+		return filepath.Join(os.TempDir(), "jailoc", "jailoc.log")
 	}
 	return filepath.Join(home, ".cache", "jailoc", "jailoc.log")
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,115 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestInitCreatesFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := Init(); err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+
+	info, err := os.Stat(logFilePath())
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", logFilePath(), err)
+	}
+
+	if got, want := info.Mode().Perm(), os.FileMode(0o640); got != want {
+		t.Fatalf("log file permissions = %v, want %v", got, want)
+	}
+}
+
+func TestInitRotatesLargeFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	logPath := logFilePath()
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o750); err != nil {
+		t.Fatalf("os.MkdirAll(%q) error = %v", filepath.Dir(logPath), err)
+	}
+
+	if err := os.WriteFile(logPath, bytesOfSize(maxLogSize+1), 0o640); err != nil { //nolint:gosec // G306: 0o640 is intentional log file permission (owner rw, group r)
+		t.Fatalf("os.WriteFile(%q) error = %v", logPath, err)
+	}
+
+	if err := Init(); err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+
+	if _, err := os.Stat(logPath + ".1"); err != nil {
+		t.Fatalf("rotated backup missing: %v", err)
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", logPath, err)
+	}
+
+	if info.Size() >= maxLogSize {
+		t.Fatalf("rotated log size = %d, want < %d", info.Size(), maxLogSize)
+	}
+}
+
+func TestInitGracefulDegradation(t *testing.T) {
+	t.Setenv("HOME", "/dev/null")
+
+	if err := Init(); err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("slog.Debug panicked: %v", r)
+		}
+	}()
+
+	slog.Debug("test")
+}
+
+func TestInitConcurrentWrites(t *testing.T) {
+	home := t.TempDir()
+	prevHome, hadHome := os.LookupEnv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("os.Setenv(HOME) error = %v", err)
+	}
+	t.Cleanup(func() {
+		if hadHome {
+			_ = os.Setenv("HOME", prevHome)
+			return
+		}
+		_ = os.Unsetenv("HOME")
+	})
+
+	t.Parallel()
+
+	if err := Init(); err != nil {
+		t.Fatalf("Init() error = %v, want nil", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := range 10 {
+		go func(i int) {
+			defer wg.Done()
+			slog.Debug("msg", "i", i)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func bytesOfSize(size int) []byte {
+	if size <= 0 {
+		return []byte{}
+	}
+
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = 'x'
+	}
+	return buf
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -85,8 +85,6 @@ func TestInitConcurrentWrites(t *testing.T) {
 		_ = os.Unsetenv("HOME")
 	})
 
-	t.Parallel()
-
 	if err := Init(); err != nil {
 		t.Fatalf("Init() error = %v, want nil", err)
 	}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -8,8 +8,19 @@ import (
 	"testing"
 )
 
+func cleanupLogFile(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if logFile != nil {
+			_ = logFile.Close()
+			logFile = nil
+		}
+	})
+}
+
 func TestInitCreatesFile(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	cleanupLogFile(t)
 
 	if err := Init(); err != nil {
 		t.Fatalf("Init() error = %v, want nil", err)
@@ -27,6 +38,7 @@ func TestInitCreatesFile(t *testing.T) {
 
 func TestInitRotatesLargeFile(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	cleanupLogFile(t)
 
 	logPath := logFilePath()
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o750); err != nil {
@@ -57,6 +69,7 @@ func TestInitRotatesLargeFile(t *testing.T) {
 
 func TestInitGracefulDegradation(t *testing.T) {
 	t.Setenv("HOME", "/dev/null")
+	cleanupLogFile(t)
 
 	if err := Init(); err != nil {
 		t.Fatalf("Init() error = %v, want nil", err)
@@ -84,6 +97,7 @@ func TestInitConcurrentWrites(t *testing.T) {
 		}
 		_ = os.Unsetenv("HOME")
 	})
+	cleanupLogFile(t)
 
 	if err := Init(); err != nil {
 		t.Fatalf("Init() error = %v, want nil", err)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -367,6 +367,7 @@ func TestCheckAsync(t *testing.T) {
 		res := recvResult(t, checkAsync(context.Background(), "v1.0.0", ts.URL, statePath))
 		if res == nil {
 			t.Fatal("expected non-nil result")
+			return
 		}
 		if res.Current != "v1.0.0" || res.Latest != "v99.0.0" {
 			t.Fatalf("unexpected result: %+v", res)
@@ -476,6 +477,7 @@ func TestCheckAsync(t *testing.T) {
 		res := recvResult(t, checkAsync(context.Background(), "v1.0.0", ts.URL, statePath))
 		if res == nil {
 			t.Fatal("expected non-nil result")
+			return
 		}
 		if res.Latest != "v2.0.0" {
 			t.Fatalf("Latest = %q, want %q", res.Latest, "v2.0.0")

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -509,6 +509,7 @@ func TestCheckAsync(t *testing.T) {
 		res := recvResult(t, checkAsync(context.Background(), "v1.0.0", ts.URL, statePath))
 		if res == nil {
 			t.Fatal("expected non-nil result")
+			return
 		}
 		if res.Latest != "v3.0.0" {
 			t.Fatalf("Latest = %q, want %q", res.Latest, "v3.0.0")

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,6 +41,8 @@ type Resolved struct {
 }
 
 func Resolve(cfg *config.Config, name string) (*Resolved, error) {
+	slog.Debug("resolving workspace", "name", name)
+
 	if cfg == nil {
 		return nil, fmt.Errorf("workspace %q not found", name)
 	}
@@ -102,7 +105,7 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 		return nil, fmt.Errorf("merge mounts for workspace %s: %w", name, err)
 	}
 
-	return &Resolved{
+	r := &Resolved{
 		Name:            name,
 		Paths:           paths,
 		Mounts:          mergedMounts,
@@ -119,7 +122,11 @@ func Resolve(cfg *config.Config, name string) (*Resolved, error) {
 		Memory:          stringWithDefault(cfg.Defaults.Memory, ws.Memory, "4g"),
 		ExposePort:      boolPtrWithDefault(cfg.Defaults.ExposePort, ws.ExposePort, true),
 		EnableDocker:    boolPtrWithDefault(cfg.Defaults.EnableDocker, ws.EnableDocker, true),
-	}, nil
+	}
+
+	slog.Debug("workspace resolved", "name", name, "port", r.Port, "paths", len(paths))
+
+	return r, nil
 }
 
 func dedupEnvByKeyLastWins(entries []string) []string {


### PR DESCRIPTION
Add background debug logging to `~/.cache/jailoc/jailoc.log` using stdlib `log/slog` with `TextHandler`.

## What

- New `internal/logging` package: `Init()`, 5MB rotation with one backup, discard fallback on failure
- `slog.SetDefault()` wired in `PersistentPreRunE` — no function signature changes anywhere
- 21 `slog.Debug`/`slog.Info` calls across all major operations (up, docker, workspace, config, compose)

## Design decisions

- Always-on `LevelDebug`, no verbosity flag — file-only, zero stderr/stdout noise
- Graceful degradation: if log file can't be opened, falls back to `io.Discard` handler (never crashes)
- `internal/logging` has zero internal imports (no dependency cycles)
- Existing `fmt.Printf`/`color.Printf` user output untouched

## Testing

- 4 unit tests in `internal/logging` (init, rotation, graceful degradation, discard fallback)
- Race-clean: `go test -race ./internal/logging/...`
- Full suite: `go test ./...` — 10 packages pass
- `golangci-lint run` — 0 issues