### PR TITLE
docs(how-to): add troubleshooting page

### DIFF
--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -100,7 +100,7 @@ See [How to allow specific hosts or networks](network-access.md) for details.
 
 **Symptom:** `jailoc up` reports errors pulling or building the container image.
 
-Image resolution follows a cascade — if one step fails, jailoc tries the next. Common causes:
+Image resolution uses a priority cascade — the first matching configuration wins, and build/pull failures at that step are fatal. Common causes:
 
 - Registry unreachable (network issues, auth required)
 - URL Dockerfile returns HTTP errors
@@ -109,11 +109,11 @@ Image resolution follows a cascade — if one step fails, jailoc tries the next.
 **Debugging:**
 
 ```bash
-# Check the log for the resolution cascade
+# Check the log for image resolution errors
 grep -Ei "image|pull|build|dockerfile" ~/.cache/jailoc/jailoc.log
 ```
 
-If all steps in the cascade fail, jailoc falls back to the embedded base image. If even that fails, check Docker daemon health.
+See [Image resolution reference](../reference/image-resolution.md) for the full cascade order.
 
 ---
 
@@ -207,11 +207,11 @@ jailoc down <workspace>
 
 # Remove stopped jailoc containers
 docker ps -a --filter "label=com.docker.compose.project" --format '{{.Names}}' \
-  | grep '^jailoc-' | xargs -r docker rm
+  | grep '^jailoc-' | xargs docker rm
 
 # Remove jailoc volumes
 docker volume ls --format '{{.Name}}' \
-  | grep '^jailoc-' | xargs -r docker volume rm
+  | grep '^jailoc-' | xargs docker volume rm
 ```
 
 ### Remove the log file

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -12,7 +12,7 @@ jailoc writes structured logs to:
 ~/.cache/jailoc/jailoc.log
 ```
 
-The log file rotates automatically at 5 MB — the previous file is kept as `jailoc.log.1`. If `~/.cache` is unreachable, logs fall back to the system temp directory (`/tmp/jailoc/jailoc.log`).
+The log file rotates automatically at 5 MB — the previous file is kept as `jailoc.log.1`. If your home directory cannot be determined, logs fall back to `$TMPDIR/jailoc/jailoc.log`. If the log file still cannot be opened, logging is silently disabled.
 
 All log entries use `slog` text format with timestamps, levels, and key-value pairs. Look for `level=ERROR` lines to find failures.
 
@@ -110,7 +110,7 @@ Image resolution follows a cascade — if one step fails, jailoc tries the next.
 
 ```bash
 # Check the log for the resolution cascade
-grep -i "image\|pull\|build\|dockerfile" ~/.cache/jailoc/jailoc.log
+grep -Ei "image|pull|build|dockerfile" ~/.cache/jailoc/jailoc.log
 ```
 
 If all steps in the cascade fail, jailoc falls back to the embedded base image. If even that fails, check Docker daemon health.
@@ -199,19 +199,23 @@ Over time, stopped workspaces may leave behind containers, volumes, and cached f
 rm -rf ~/.cache/jailoc/<workspace>/
 ```
 
-### Remove all jailoc Docker resources
+### Remove jailoc Docker resources
 
 ```bash
-# Stop all running workspaces
+# Stop a workspace
 jailoc down <workspace>
 
-# Prune containers and volumes with the jailoc label
-docker ps -a --filter "label=com.docker.compose.project" | grep jailoc
-docker volume ls --filter "label=com.docker.compose.project" | grep jailoc
+# Remove stopped jailoc containers
+docker ps -a --filter "label=com.docker.compose.project" --format '{{.Names}}' \
+  | grep '^jailoc-' | xargs -r docker rm
+
+# Remove jailoc volumes
+docker volume ls --format '{{.Name}}' \
+  | grep '^jailoc-' | xargs -r docker volume rm
 ```
 
 ### Remove the log file
 
 ```bash
-rm ~/.cache/jailoc/jailoc.log ~/.cache/jailoc/jailoc.log.1
+rm -f ~/.cache/jailoc/jailoc.log ~/.cache/jailoc/jailoc.log.1
 ```

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -12,7 +12,7 @@ jailoc writes structured logs to:
 ~/.cache/jailoc/jailoc.log
 ```
 
-The log file rotates at startup when it exceeds 5 MB — the previous file is kept as `jailoc.log.1`. If your home directory cannot be determined, logs fall back to `$TMPDIR/jailoc/jailoc.log`. If the log file still cannot be opened, logging is silently disabled.
+The log file rotates at startup when it exceeds 5 MB — the previous file is renamed to `jailoc.log.1`. If the rename fails, the log file is truncated instead (so `.1` may not exist on every system). If your home directory cannot be determined, logs fall back to `$TMPDIR/jailoc/jailoc.log`. If the log file still cannot be opened, logging is silently disabled.
 
 All log entries use `slog` text format with timestamps, levels, and key-value pairs. Look for `level=ERROR` lines to find failures.
 
@@ -89,7 +89,7 @@ allowed_networks = ["10.10.5.0/24"]
 Then restart the workspace:
 
 ```bash
-jailoc down myproject && jailoc up myproject
+jailoc restart myproject
 ```
 
 See [How to allow specific hosts or networks](network-access.md) for details.
@@ -180,12 +180,6 @@ Common causes:
 - Host does not support privileged containers (some CI environments)
 - TLS certificate volume not properly shared between containers
 - Insufficient disk space for Docker data volume
-
-**Fix:** Restart the workspace to regenerate TLS certificates and volumes:
-
-```bash
-jailoc down <workspace> && jailoc up <workspace>
-```
 
 ---
 

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -1,0 +1,217 @@
+# Troubleshooting
+
+Common issues and debugging steps for jailoc workspaces.
+
+---
+
+## Find log files
+
+jailoc writes structured logs to:
+
+```
+~/.cache/jailoc/jailoc.log
+```
+
+The log file rotates automatically at 5 MB — the previous file is kept as `jailoc.log.1`. If `~/.cache` is unreachable, logs fall back to the system temp directory (`/tmp/jailoc/jailoc.log`).
+
+All log entries use `slog` text format with timestamps, levels, and key-value pairs. Look for `level=ERROR` lines to find failures.
+
+---
+
+## Docker daemon not running
+
+**Symptom:** `jailoc up` fails immediately with a Docker connection error.
+
+**Fix:** Start the Docker daemon:
+
+```bash
+# Linux (systemd)
+sudo systemctl start docker
+
+# macOS (Docker Desktop)
+open -a Docker
+```
+
+Verify with `docker info` before retrying.
+
+---
+
+## Port conflicts
+
+**Symptom:** `jailoc up` fails with "address already in use" or the container starts but attach fails with connection refused.
+
+Ports are assigned as `4096 + alphabetical index` among all configured workspaces. If another process occupies that port:
+
+```bash
+# Find what's using the port (e.g. 4096)
+lsof -i :4096
+```
+
+**Fix:** Stop the conflicting process, or add/remove/rename workspaces to shift the port assignment. Run `jailoc status` to see the assigned port for each workspace.
+
+---
+
+## Permission denied on bind mounts
+
+**Symptom:** Container starts but the agent reports permission errors reading or writing mounted paths.
+
+The agent runs as UID 1000 inside the container. The mounted host directories must be readable (and writable, for workspace paths) by UID 1000.
+
+**Fix:**
+
+```bash
+# Check ownership
+ls -ln /path/to/mounted/dir
+
+# Fix if needed
+sudo chown -R 1000:1000 /path/to/mounted/dir
+```
+
+!!! note
+    On macOS with Docker Desktop, file sharing handles UID mapping automatically. This issue primarily affects Linux hosts.
+
+---
+
+## Network restrictions blocking required hosts
+
+**Symptom:** The agent cannot reach an internal service (registry, MCP server, API) — connections time out or get refused.
+
+jailoc blocks all RFC 1918, link-local, and CGNAT addresses by default. If a required service lives on a private address, it must be explicitly allowed.
+
+**Fix:** Add the host or network to your workspace config:
+
+```toml
+[workspaces.myproject]
+allowed_hosts = ["internal-registry.example.com"]
+allowed_networks = ["10.10.5.0/24"]
+```
+
+Then restart the workspace:
+
+```bash
+jailoc down myproject && jailoc up myproject
+```
+
+See [How to allow specific hosts or networks](network-access.md) for details.
+
+---
+
+## Image pull failures
+
+**Symptom:** `jailoc up` reports errors pulling or building the container image.
+
+Image resolution follows a cascade — if one step fails, jailoc tries the next. Common causes:
+
+- Registry unreachable (network issues, auth required)
+- URL Dockerfile returns HTTP errors
+- Local Dockerfile path does not exist
+
+**Debugging:**
+
+```bash
+# Check the log for the resolution cascade
+grep -i "image\|pull\|build\|dockerfile" ~/.cache/jailoc/jailoc.log
+```
+
+If all steps in the cascade fail, jailoc falls back to the embedded base image. If even that fails, check Docker daemon health.
+
+---
+
+## Container does not start
+
+**Symptom:** `jailoc up` completes but `jailoc status` shows the workspace is not running.
+
+**Debugging:**
+
+```bash
+# Check container logs for startup errors
+jailoc logs <workspace>
+```
+
+Common causes:
+
+- Entrypoint script fails (iptables errors if running without required capabilities)
+- Bind-mount source path does not exist on host
+- Insufficient disk space for volumes
+
+---
+
+## Attach fails or connection refused
+
+**Symptom:** `jailoc attach` exits immediately or reports connection refused.
+
+**Debugging:**
+
+1. Confirm the workspace is running:
+
+    ```bash
+    jailoc status
+    ```
+
+2. Check that the opencode process started inside the container:
+
+    ```bash
+    jailoc logs <workspace>
+    ```
+
+3. Verify the port is listening:
+
+    ```bash
+    lsof -i :<port>
+    ```
+
+If the container is running but opencode did not start, check the container logs for entrypoint errors (e.g. permission issues, missing config).
+
+---
+
+## DinD sidecar not healthy
+
+**Symptom:** Docker commands inside the workspace fail — the agent cannot build images or run containers.
+
+The DinD (Docker-in-Docker) sidecar runs a separate Docker daemon on TLS port 2376. If it is unhealthy:
+
+```bash
+# Check sidecar logs
+jailoc logs <workspace>
+```
+
+Common causes:
+
+- Host does not support privileged containers (some CI environments)
+- TLS certificate volume not properly shared between containers
+- Insufficient disk space for Docker data volume
+
+**Fix:** Restart the workspace to regenerate TLS certificates and volumes:
+
+```bash
+jailoc down <workspace> && jailoc up <workspace>
+```
+
+---
+
+## Cleanup stale resources
+
+Over time, stopped workspaces may leave behind containers, volumes, and cached files.
+
+### Remove cached compose files
+
+```bash
+rm -rf ~/.cache/jailoc/<workspace>/
+```
+
+### Remove all jailoc Docker resources
+
+```bash
+# Stop all running workspaces
+jailoc down <workspace>
+
+# Prune containers and volumes with the jailoc label
+docker ps -a --filter "label=com.docker.compose.project" | grep jailoc
+docker volume ls --filter "label=com.docker.compose.project" | grep jailoc
+```
+
+### Remove the log file
+
+```bash
+rm ~/.cache/jailoc/jailoc.log ~/.cache/jailoc/jailoc.log.1
+```

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -12,7 +12,7 @@ jailoc writes structured logs to:
 ~/.cache/jailoc/jailoc.log
 ```
 
-The log file rotates automatically at 5 MB — the previous file is kept as `jailoc.log.1`. If your home directory cannot be determined, logs fall back to `$TMPDIR/jailoc/jailoc.log`. If the log file still cannot be opened, logging is silently disabled.
+The log file rotates at startup when it exceeds 5 MB — the previous file is kept as `jailoc.log.1`. If your home directory cannot be determined, logs fall back to `$TMPDIR/jailoc/jailoc.log`. If the log file still cannot be opened, logging is silently disabled.
 
 All log entries use `slog` text format with timestamps, levels, and key-value pairs. Look for `level=ERROR` lines to find failures.
 
@@ -202,14 +202,14 @@ rm -rf ~/.cache/jailoc/<workspace>/
 ### Remove jailoc Docker resources
 
 ```bash
-# Stop a workspace
+# Stop all workspaces first
 jailoc down <workspace>
 
-# Remove stopped jailoc containers
-docker ps -a --filter "label=com.docker.compose.project" --format '{{.Names}}' \
-  | grep '^jailoc-' | xargs docker rm
+# Remove exited jailoc containers
+docker ps -a --filter "label=com.docker.compose.project" --filter "status=exited" \
+  --format '{{.Names}}' | grep '^jailoc-' | xargs docker rm
 
-# Remove jailoc volumes
+# Remove jailoc volumes (all workspaces must be stopped)
 docker volume ls --format '{{.Name}}' \
   | grep '^jailoc-' | xargs docker volume rm
 ```

--- a/docs/how-to/troubleshooting.md
+++ b/docs/how-to/troubleshooting.md
@@ -196,7 +196,7 @@ rm -rf ~/.cache/jailoc/<workspace>/
 ### Remove jailoc Docker resources
 
 ```bash
-# Stop all workspaces first
+# Stop each workspace first (repeat for every running workspace)
 jailoc down <workspace>
 
 # Remove exited jailoc containers

--- a/docs/how-to/tui-plugin.md
+++ b/docs/how-to/tui-plugin.md
@@ -31,7 +31,7 @@ The `tui-plugin` directory is shared across all workspaces — jailoc writes it 
 Restart the workspace to apply the plugin configuration:
 
 ```bash
-jailoc down <name> && jailoc up <name>
+jailoc restart <name>
 ```
 
 ---
@@ -56,4 +56,4 @@ Verify jailoc generated the TUI config and plugin files:
 ls ~/.cache/jailoc/tui.json ~/.cache/jailoc/tui-container.json ~/.cache/jailoc/tui-plugin/
 ```
 
-If they are missing, restart any workspace with `jailoc down <name> && jailoc up <name>`.
+If they are missing, restart any workspace with `jailoc restart <name>`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ Step-by-step guides for specific tasks once you're up and running.
 - [Network Access](how-to/network-access.md)
 - [SSH & Git Passthrough](how-to/ssh-git-passthrough.md)
 - [Access Modes](how-to/access-modes.md)
+- [Troubleshooting](how-to/troubleshooting.md)
 
 ### Reference
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,6 +27,7 @@ Key facts:
 - [SSH & Git Passthrough](https://seznam.github.io/jailoc/how-to/ssh-git-passthrough/): Forward SSH agent (with known_hosts), mount Git config into containers
 - [Access Modes](https://seznam.github.io/jailoc/how-to/access-modes/): Remote vs exec mode configuration
 - [TUI Plugin](https://seznam.github.io/jailoc/how-to/tui-plugin/): Enable the TUI sidebar plugin to show workspace context in the OpenCode sidebar
+- [Troubleshooting](https://seznam.github.io/jailoc/how-to/troubleshooting/): Find logs, debug common errors, fix container issues, clean up stale resources
 
 ## Explanation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - SSH & Git Passthrough: how-to/ssh-git-passthrough.md
     - Access Modes: how-to/access-modes.md
     - TUI Plugin: how-to/tui-plugin.md
+    - Troubleshooting: how-to/troubleshooting.md
   - Reference:
     - CLI: reference/cli.md
     - Configuration: reference/configuration.md


### PR DESCRIPTION
Add `docs/how-to/troubleshooting.md` covering common issues and debugging steps.

Covers:
- Finding log files and rotation behavior
- Docker daemon not running
- Port conflicts
- Permission denied on bind mounts
- Network restrictions blocking required hosts
- Image pull failures and fallback cascade
- Container startup failures
- Attach/connection issues
- DinD sidecar health
- Stale resource cleanup

Also updates `mkdocs.yml` nav, `docs/llms.txt`, and `docs/index.md`.

Closes #173