### PR TITLE
fix(cmd): unwrap build errors, remove premature startup message

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -123,10 +123,9 @@ var rootCmd = &cobra.Command{
 		}
 
 		if !running {
-			_, _ = color.New(color.FgCyan).Printf("Starting workspace %s...\n", ws.Name)
 			workspaceExplicit = true
 			if err := runUp(ctx, nil); err != nil {
-				return fmt.Errorf("start workspace %q: %w", ws.Name, err)
+				return err
 			}
 			_, _ = color.New(color.FgCyan).Printf("Waiting for OpenCode to be ready...\n")
 			if err := waitForReadiness(ctx, ws.Port, ws.ExposePort, client); err != nil {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -628,6 +628,12 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 		return "", fmt.Errorf("close temporary workspace Dockerfile %q: %w", tmpDockerfilePath, err)
 	}
 
+	// Workspace overlays are rebuilt unconditionally on every jailoc up.
+	// We do NOT check whether overlayTag already exists locally and skip the build —
+	// that would silently run a stale image when the user edits their Dockerfile
+	// but the edit produces a build error. Build failure must abort startup.
+	// Daemon-side layer cache already provides the fast path for unchanged Dockerfiles;
+	// adding a second cache layer here would only mask user errors.
 	hash := sha256.Sum256(dockerfileContent)
 	hashHex := fmt.Sprintf("%x", hash)
 	overlayTag := fmt.Sprintf("jailoc-%s:%s", ws.Name, hashHex[:8])

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -628,7 +628,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 		return "", fmt.Errorf("close temporary workspace Dockerfile %q: %w", tmpDockerfilePath, err)
 	}
 
-	// Workspace overlays are rebuilt unconditionally on every jailoc up.
+	// Workspace overlays are rebuilt unconditionally on every workspace startup.
 	// We do NOT check whether overlayTag already exists locally and skip the build —
 	// that would silently run a stale image when the user edits their Dockerfile
 	// but the edit produces a build error. Build failure must abort startup.


### PR DESCRIPTION
### Problem
On the `jailoc` command itself (not `jailoc up`), overlay build failures
were wrapped as `start workspace "X": ...` and preceded by a misleading
`Starting workspace X...` print — both fired before startup was attempted.
### Fix
Return `runUp`'s error directly, matching `jailoc up` and `jailoc restart`.
Additionally documents in `docker.go` that overlay builds run unconditionally
with no cached-image fallback on failure — silent fallback would mask stale
Dockerfile edits.
### Reproduction
Run `jailoc` (not `jailoc up`) from a workspace directory whose Dockerfile
produces a build error, with the workspace not running.
### Log example
**Before:**
```
Starting workspace abcd...
...
Error: start workspace "abcd": resolve image for workspace "abcd": ...
```
**After:**
```
Error: resolve image for workspace "abcd": ...