### PR TITLE
fix(docker): prepend ARG BASE to overlay Dockerfiles

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -607,6 +607,10 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 		return "", fmt.Errorf("load workspace dockerfile from %q: %w", ws.Dockerfile, err)
 	}
 
+	// Ensure BASE is declared as a global ARG so Docker can substitute it in FROM instructions.
+	// This is a no-op if the Dockerfile already declares ARG BASE — duplicate bare ARGs are harmless.
+	dockerfileContent = append([]byte("ARG BASE\n"), dockerfileContent...)
+
 	buildContextDir, cleanupCtx, err := resolveOverlayBuildContext(ws)
 	if err != nil {
 		return "", fmt.Errorf("determine build context for workspace %q: %w", ws.Name, err)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -607,9 +607,7 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 		return "", fmt.Errorf("load workspace dockerfile from %q: %w", ws.Dockerfile, err)
 	}
 
-	// Ensure BASE is declared as a global ARG so Docker can substitute it in FROM instructions.
-	// This is a no-op if the Dockerfile already declares ARG BASE — duplicate bare ARGs are harmless.
-	dockerfileContent = append([]byte("ARG BASE\n"), dockerfileContent...)
+	dockerfileContent = injectBaseArg(dockerfileContent)
 
 	buildContextDir, cleanupCtx, err := resolveOverlayBuildContext(ws)
 	if err != nil {
@@ -675,6 +673,34 @@ func BuildOverlayImage(ctx context.Context, base string, ws workspace.Resolved) 
 	}
 
 	return overlayTag, nil
+}
+
+// injectBaseArg inserts "ARG BASE\n" after any leading parser directives (# syntax=...,
+// # escape=..., # check=...) so that ${BASE} is substitutable in FROM instructions without
+// breaking directives that must appear before any instruction.
+func injectBaseArg(content []byte) []byte {
+	const argLine = "ARG BASE\n"
+	i := 0
+	for i < len(content) {
+		lineEnd := i
+		for lineEnd < len(content) && content[lineEnd] != '\n' {
+			lineEnd++
+		}
+		if lineEnd < len(content) {
+			lineEnd++
+		}
+		line := strings.TrimSpace(string(content[i:lineEnd]))
+		if line == "" || (strings.HasPrefix(line, "#") && strings.Contains(line, "=")) {
+			i = lineEnd
+			continue
+		}
+		break
+	}
+	result := make([]byte, 0, len(content)+len(argLine))
+	result = append(result, content[:i]...)
+	result = append(result, argLine...)
+	result = append(result, content[i:]...)
+	return result
 }
 
 func resolveOverlayBuildContext(ws workspace.Resolved) (dir string, cleanup func(), err error) {

--- a/internal/docker/docker_integration_test.go
+++ b/internal/docker/docker_integration_test.go
@@ -125,6 +125,29 @@ func TestBuildEmbeddedImage(t *testing.T) {
 	}
 }
 
+func TestBuildOverlayImageImplicitBaseArg(t *testing.T) {
+	t.Parallel()
+	skipWithoutDocker(t)
+
+	tmpDir := t.TempDir()
+	wsDockerfile := filepath.Join(tmpDir, "overlay.Dockerfile")
+	// Dockerfile uses ${BASE} without declaring ARG BASE — jailoc must prepend it automatically.
+	if err := os.WriteFile(wsDockerfile, []byte("FROM ${BASE}\nRUN echo hello\n"), 0o600); err != nil {
+		t.Fatalf("write workspace dockerfile: %v", err)
+	}
+
+	_, err := BuildOverlayImage(context.Background(), "registry.example.com/base:v1", workspace.Resolved{
+		Name:       "ws-implicit-base",
+		Dockerfile: wsDockerfile,
+	})
+	if err == nil {
+		t.Fatal("expected docker build error (image pull), got nil")
+	}
+	if strings.Contains(err.Error(), "should not be blank") {
+		t.Fatalf("BASE arg was not injected: %v", err)
+	}
+}
+
 func TestBuildOverlayImageExplicitBuildContext(t *testing.T) {
 	t.Parallel()
 	skipWithoutDocker(t)

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -334,6 +334,57 @@ func TestBuildOverlayImageDockerfileLoadError(t *testing.T) {
 	}
 }
 
+func TestInjectBaseArg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain FROM",
+			input: "FROM ${BASE}\nRUN echo hello\n",
+			want:  "ARG BASE\nFROM ${BASE}\nRUN echo hello\n",
+		},
+		{
+			name:  "already has ARG BASE",
+			input: "ARG BASE\nFROM ${BASE}\nRUN echo hello\n",
+			want:  "ARG BASE\nARG BASE\nFROM ${BASE}\nRUN echo hello\n",
+		},
+		{
+			name:  "syntax directive preserved",
+			input: "# syntax=docker/dockerfile:1\nFROM ${BASE}\n",
+			want:  "# syntax=docker/dockerfile:1\nARG BASE\nFROM ${BASE}\n",
+		},
+		{
+			name:  "escape directive preserved",
+			input: "# escape=`\nFROM ${BASE}\n",
+			want:  "# escape=`\nARG BASE\nFROM ${BASE}\n",
+		},
+		{
+			name:  "multiple directives",
+			input: "# syntax=docker/dockerfile:1\n# escape=`\nFROM ${BASE}\n",
+			want:  "# syntax=docker/dockerfile:1\n# escape=`\nARG BASE\nFROM ${BASE}\n",
+		},
+		{
+			name:  "directive with blank line separator",
+			input: "# syntax=docker/dockerfile:1\n\nFROM ${BASE}\n",
+			want:  "# syntax=docker/dockerfile:1\n\nARG BASE\nFROM ${BASE}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(injectBaseArg([]byte(tt.input)))
+			if got != tt.want {
+				t.Fatalf("injectBaseArg(%q)\n got: %q\nwant: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProxyBuildArgs(t *testing.T) {
 	t.Run("collects set proxy vars", func(t *testing.T) {
 		t.Setenv("HTTP_PROXY", "http://proxy:8080")


### PR DESCRIPTION
Overlay Dockerfiles that use `FROM ${BASE}` without declaring `ARG BASE` in global scope fail with:

```
base name (${BASE}) should not be blank
```

Docker requires the ARG declared before the first FROM for substitution to work. This prepends `ARG BASE\n` to every loaded overlay Dockerfile — harmless when already declared (duplicate bare ARGs are no-ops), and `--build-arg` always overrides any default.