### PR TITLE
fix(cmd): close parent's PTY slave fd to unblock attach on child exit

### DIFF
--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -207,6 +207,15 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 		return fmt.Errorf("start command with pty: %w", err)
 	}
 
+	// Close the parent's copy of the PTY slave fd. The child has already dup'd
+	// it onto stdin/stdout/stderr via fork-exec; keeping our copy open would
+	// prevent the master from ever returning EOF/EIO when the child exits,
+	// causing io.Copy(rw, p) below to block forever (e.g. after the user
+	// terminates opencode from inside the TUI).
+	if unixP, ok := p.(gopty.UnixPty); ok {
+		_ = unixP.Slave().Close()
+	}
+
 	waitDone := make(chan struct{})
 	closeWaitDone := sync.OnceFunc(func() { close(waitDone) })
 	defer closeWaitDone()

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -213,7 +213,11 @@ func attachOnHost(ctx context.Context, ws *workspace.Resolved, dir string, passw
 	// causing io.Copy(rw, p) below to block forever (e.g. after the user
 	// terminates opencode from inside the TUI).
 	if unixP, ok := p.(gopty.UnixPty); ok {
-		_ = unixP.Slave().Close()
+		if err := unixP.Slave().Close(); err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			return fmt.Errorf("close pty slave: %w", err)
+		}
 	}
 
 	waitDone := make(chan struct{})


### PR DESCRIPTION
## Summary
Fixes a hang where `jailoc up`/`jailoc attach` (host-attach mode) would freeze
the terminal in raw mode after the user quit OpenCode with Ctrl-C, swallowing
any subsequent SIGINT/SIGTERM.
## Symptom
When attached to a workspace in remote/host-attach mode, pressing Ctrl-C
inside the OpenCode TUI:
- terminated `opencode` (correct), but
- left `jailoc` blocked indefinitely,
- with the host terminal stuck in raw mode (no echo, no line buffering),
- and the `signal.NotifyContext` handler installed in `Execute` swallowing
  follow-up Ctrl-C presses, so the only recovery was `pkill -9` from another
  shell followed by `reset`.
## Root cause
`attachOnHost` runs the child `opencode` under a PTY created via
`github.com/aymanbagabas/go-pty`. That library's `Command(...)` wires the
slave fd onto the child's stdin/stdout/stderr but **does not close the
parent's copy of the slave** after `cmd.Start()`.
A PTY master only returns `EIO` on read once *every* open reference to the
slave is gone. With jailoc holding an extra slave reference, the master read
in `io.Copy(rw, p)` never unblocks when the child exits, `cmd.Wait()` is
never reached, and the deferred `term.Restore` never runs.
This was a regression from #166 ("replace creack/pty with go-pty"). The
previous library closed the parent slave for us; `go-pty`'s lower-level API
leaves it to the caller.
## Fix
After `cmd.Start()`, close the parent's slave fd via the
`gopty.UnixPty.Slave()` accessor. The child has already inherited its own
fds via fork+exec, so closing the parent side is safe and is exactly what
allows the master to reach EOF when the child exits. `unixPty.Close()` later
in the deferred cleanup remains safe — it joins errors across both fds and
the caller already discards the result.
```go
cmd := p.Command(binary, args...)
cmd.Env = env
if err := cmd.Start(); err != nil {
    return fmt.Errorf("start command with pty: %w", err)
}
// Close the parent's copy of the PTY slave fd. The child has already dup'd
// it onto stdin/stdout/stderr via fork-exec; keeping our copy open would
// prevent the master from ever returning EOF/EIO when the child exits,
// causing io.Copy(rw, p) below to block forever.
if unixP, ok := p.(gopty.UnixPty); ok {
    _ = unixP.Slave().Close()
}
```
## Test plan
Manual, on Linux, against a host-attach workspace:
1. go build -o ./jailoc ./cmd/jailoc
2. ./jailoc up <workspace>
3. Inside the OpenCode TUI, press Ctrl-C.
4. Before this fix: terminal hangs in raw mode, follow-up Ctrl-C
   ignored, requires pkill -9 jailoc + reset.
5. After this fix: opencode exits, jailoc exits, shell prompt
   returns, stty -a shows cooked mode (icanon echo).
Also verified:
- go build ./...
- go vet ./...
- go test ./internal/cmd/...
attachExec (in-container Docker exec path) is unaffected — it does not
use the local PTY.

## Risk
Low. Single-line behavior change limited to the host-attach path, guarded
by a type assertion to gopty.UnixPty so non-Unix builds no-op. Restores
the pre-#166 behavior.

Refs: #166