### PR TITLE
chore: bump embedded tool and CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -34,7 +34,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -42,13 +42,13 @@ jobs:
           go-version: "1.26.x"
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.11.4
+          version: v2.12.2
 
   tui-plugin-sync:
     name: TUI Plugin Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -64,7 +64,7 @@ jobs:
     env:
       OPENCODE_SERVER_PASSWORD: integration-test-password
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/nix-vendor-hash.yml
+++ b/.github/workflows/nix-vendor-hash.yml
@@ -25,7 +25,7 @@ jobs:
     name: Update vendorHash
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
       - name: Update vendor hash

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,11 +38,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{ needs.release-please.outputs.sha }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Run `go build`, `go test ./...`, and `golangci-lint run` inside as usual.
 ## CI/CD
 
 GitHub Actions workflows:
-- **CI** (`.github/workflows/ci.yml`): runs on push/PR to master — `go build`, `go test`, `go vet`, and golangci-lint v2.11.4 (gosec, staticcheck, gocritic)
+- **CI** (`.github/workflows/ci.yml`): runs on push/PR to master — `go build`, `go test`, `go vet`, and golangci-lint v2.12.2 (gosec, staticcheck, gocritic)
 - **Release** (`.github/workflows/release-please.yml`): runs on push to main — Release Please opens a Release PR; on merge, creates `v*` tag + GitHub Release, then GoReleaser publishes binaries (Linux/Darwin × amd64/arm64, `CGO_ENABLED=0`)
 - **Re-release** (`.github/workflows/release.yml`): manual `workflow_dispatch` fallback — re-runs GoReleaser for an existing tag
 - **Docs** (`.github/workflows/release-please.yml`): runs as part of the release process — zensical + mkdocs-macros-plugin → GitHub Pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 - Go 1.26+
 - Docker (required for integration tests)
-- [golangci-lint](https://golangci-lint.run/welcome/install/) v2.11.4
+- [golangci-lint](https://golangci-lint.run/welcome/install/) v2.12.2
 
 ## Local setup
 

--- a/dev/Dockerfile.jailoc
+++ b/dev/Dockerfile.jailoc
@@ -14,7 +14,7 @@ FROM ${BASE}
 
 # Go toolchain — required by golangci-lint and gopls at runtime.
 # renovate: datasource=golang-version depName=go
-ARG GO_VERSION=1.26.1
+ARG GO_VERSION=1.26.4
 RUN set -eux; \
     ARCH=$(dpkg --print-architecture); \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \
@@ -23,12 +23,12 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 
 # gopls — Go language server for OpenCode code intelligence (go-to-definition, completions, diagnostics).
 # renovate: datasource=go depName=golang.org/x/tools/gopls
-ARG GOPLS_VERSION=v0.21.1
+ARG GOPLS_VERSION=v0.22.0
 RUN GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@${GOPLS_VERSION}
 
 # golangci-lint — static analysis matching CI (gosec, staticcheck, gocritic).
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-ARG GOLANGCI_LINT_VERSION=v2.11.4
+ARG GOLANGCI_LINT_VERSION=v2.12.2
 RUN set -eux; \
     ARCH=$(dpkg --print-architecture); \
     curl -fsSL "https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/golangci-lint-${GOLANGCI_LINT_VERSION#v}-linux-${ARCH}.tar.gz" \

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seznam/jailoc
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seznam/jailoc
 
-go 1.26.4
+go 1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/internal/embed/assets/Dockerfile
+++ b/internal/embed/assets/Dockerfile
@@ -16,19 +16,19 @@
 # Pinned versions — Renovate comments tell the bot which datasource to poll
 # for automated version-bump PRs.
 # renovate: datasource=node-version depName=node versioning=node
-ARG NODE_VERSION=26.3.0
+ARG NODE_VERSION=26.4.0
 # renovate: datasource=npm depName=yaml-language-server
 ARG YAML_LS_VERSION=1.23.0
 # renovate: datasource=npm depName=typescript-language-server
-ARG TS_LS_VERSION=5.1.3
+ARG TS_LS_VERSION=5.3.0
 # renovate: datasource=npm depName=typescript
 ARG TS_VERSION=6.0.3
 # renovate: datasource=npm depName=pyright
-ARG PYRIGHT_VERSION=1.1.409
+ARG PYRIGHT_VERSION=1.1.410
 # renovate: datasource=npm depName=bash-language-server
 ARG BASH_LS_VERSION=5.6.0
 # renovate: datasource=github-releases depName=sst/opencode
-ARG OPENCODE_VERSION=v1.15.13
+ARG OPENCODE_VERSION=v1.17.11
 
 # =============================================================================
 # Builder stage — compile language servers and install npm modules.


### PR DESCRIPTION
Bump all outdated pinned versions to latest stable releases.

### Embedded Dockerfile
- Node.js 26.3.0 → 26.4.0
- typescript-language-server 5.1.3 → 5.3.0
- Pyright 1.1.409 → 1.1.410
- OpenCode v1.15.13 → v1.17.11

### Dev Dockerfile
- Go 1.26.1 → 1.26.4
- gopls v0.21.1 → v0.22.0
- golangci-lint v2.11.4 → v2.12.2

### GitHub Actions
- actions/checkout v6.0.3 → v7.0.0 (SHA-pinned)
- actions/setup-python v6.2.0 → v6.3.0 (SHA-pinned)
- golangci-lint version v2.11.4 → v2.12.2

### Other
- `go.mod` directive 1.26.1 → 1.26.4
- Docs: golangci-lint version refs updated