### PR TITLE
feat(internal/compose): Allow localhost gateway traffic

### DIFF
--- a/internal/compose/compose_test.go
+++ b/internal/compose/compose_test.go
@@ -42,6 +42,7 @@ func TestGenerateComposeSinglePath(t *testing.T) {
 	assertContains(t, rendered, "$$OPENCODE_SERVER_PASSWORD")
 	assertContains(t, rendered, "/global/health")
 	assertContains(t, rendered, "entrypoint.sh:/usr/local/bin/entrypoint.sh:ro")
+	assertContains(t, rendered, `- "host.docker.internal:host-gateway"`)
 }
 
 func TestGenerateComposeMultiplePaths(t *testing.T) {

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -64,6 +64,8 @@ services:
       - CHOWN             # chown data dirs before drop
       - FOWNER            # bypass ownership checks on chown
       - DAC_READ_SEARCH   # traverse restricted dirs during chown
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     stdin_open: true
     tty: true
     mem_limit: "{{.Memory}}"

--- a/internal/embed/assets/docker-compose.yml.tmpl
+++ b/internal/embed/assets/docker-compose.yml.tmpl
@@ -70,6 +70,8 @@ services:
       - CHOWN             # chown data dirs before drop
       - FOWNER            # bypass ownership checks on chown
       - DAC_READ_SEARCH   # traverse restricted dirs during chown
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     stdin_open: true
     tty: true
     mem_limit: "{{.Memory}}"

--- a/internal/embed/assets/entrypoint.sh
+++ b/internal/embed/assets/entrypoint.sh
@@ -47,7 +47,7 @@ fi
 
 HOST_IP=$(getent hosts host.docker.internal | awk '{print $1}' || true)
 if [ -n "$HOST_IP" ]; then
-  $IPT -I OUTPUT -d "$HOST_IP" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  $IPT -I OUTPUT -d "$HOST_IP" -j ACCEPT
 fi
 
 for GW in $(awk '$3 != "00000000" && $3 != "Gateway" {print $3}' /proc/net/route | sort -u); do


### PR DESCRIPTION
Adds the `host.docker.internal` gateway and accepts traffic to it in order to allow connections to localhost (host machine) MCP servers.